### PR TITLE
Nouvel écran de fin

### DIFF
--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -10,7 +10,7 @@ import { motion } from 'framer-motion'
 import BallonGES from './images/ballonGES.svg'
 import StartingBlock from './images/starting block.svg'
 import SessionBar from 'Components/SessionBar'
-import Chart from './chart'
+import ClimateTargetChart from './chart/ClimateTargetChart'
 import { Link } from 'react-router-dom'
 
 const gradient = tinygradient([
@@ -140,7 +140,12 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 					</div>
 				</div>
 				<div css="padding: 1rem">
-					<Chart details={details} color={textColor} noAnimation noText />
+					<ClimateTargetChart
+						details={details}
+						color={textColor}
+						noAnimation
+						noText
+					/>
 				</div>
 
 				<div css="display: flex; flex-direction: column;">

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -86,61 +86,13 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 				`}
 			>
 				<div css="display: flex; align-items: center; justify-content: center">
+					<h1>Mon empreinte climat</h1>
 					<img src={BallonGES} css="height: 10rem" />
-					<div>
-						<div css="font-weight: bold; font-size: 280%; margin-bottom: .3rem">
-							<span css="width: 3.6rem; text-align: right; display: inline-block">
-								{Math.round(value / 1000)}
-							</span>{' '}
-							tonnes
-						</div>
-						<div
-							css={`
-								background: #ffffff3d;
-								border-radius: 0.6rem;
-								margin: 0 auto;
-								padding: 0.4rem 1rem;
-
-								> div {
-									display: flex;
-									justify-content: space-between;
-									flex-wrap: wrap;
-								}
-								strong {
-									font-weight: bold;
-								}
-								> img {
-									margin: 0 0.6rem !important;
-								}
-							`}
-						>
-							<div>
-								<span>
-									{emoji('🇫🇷 ')}
-									moyenne{' '}
-								</span>{' '}
-								<strong> 11 tonnes</strong>
-							</div>
-							<div>
-								<span>
-									{emoji('🎯 ')}
-									objectif{' '}
-								</span>
-								<strong>2 tonnes</strong>
-							</div>
-							<div css="margin-top: .2rem;justify-content: flex-end !important">
-								<a
-									css="color: inherit"
-									href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"
-								>
-									Comment ça ?
-								</a>
-							</div>
-						</div>
-					</div>
+					<div></div>
 				</div>
 				<div css="padding: 1rem">
 					<ClimateTargetChart
+						value={value}
 						details={details}
 						color={textColor}
 						noAnimation

--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -85,20 +85,13 @@ const AnimatedDiv = animated(({ score, value, details }) => {
 					font-size: 110%;
 				`}
 			>
-				<div css="display: flex; align-items: center; justify-content: center">
-					<h1>Mon empreinte climat</h1>
-					<img src={BallonGES} css="height: 10rem" />
-					<div></div>
-				</div>
-				<div css="padding: 1rem">
-					<ClimateTargetChart
-						value={value}
-						details={details}
-						color={textColor}
-						noAnimation
-						noText
-					/>
-				</div>
+				<ClimateTargetChart
+					value={value}
+					details={details}
+					color={textColor}
+					noAnimation
+					noText
+				/>
 
 				<div css="display: flex; flex-direction: column;">
 					<ShareButton

--- a/source/sites/publicodes/chart/ClimateTargetChart.js
+++ b/source/sites/publicodes/chart/ClimateTargetChart.js
@@ -10,7 +10,9 @@ import { getRuleFromAnalysis, encodeRuleName } from 'Engine/rules'
 import Bar from './Bar'
 import emoji from 'react-easy-emoji'
 
-export default ({ details, color, noText }) => {
+const sustainableLifeGoal = [2000, '2 tonnes']
+
+export default ({ details, color, noText, value }) => {
 	const analysis = useSelector(analysisWithDefaultsSelector),
 		rules = useSelector(parsedRulesSelector)
 
@@ -33,53 +35,85 @@ export default ({ details, color, noText }) => {
 				padding: 0;
 			`}
 		>
+			<a
+				css="color: inherit"
+				href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"
+			>
+				Comment ça ?
+			</a>
 			<div
 				css={`
 					position: relative;
+					display: flex;
+					justify-content: space-evenly;
+					align-items: flex-end;
+					height: 18rem;
 				`}
 			>
-				<ul
+				<div css="height: 100%">
+					<div css="line-height: 1.2rem">
+						{Math.round(value / 1000)} <br />
+						tonnes
+					</div>
+					<ul
+						css={`
+							margin: 0;
+							width: 4rem;
+							height: calc(100% - 2.4rem);
+							border-radius: 0.3rem;
+							border: 3px solid ${color};
+							padding: 0;
+						`}
+					>
+						{categories.map((category) => (
+							<li
+								key={category.title}
+								css={`
+									margin: 0;
+									list-style-type: none;
+									> a {
+										display: block;
+										text-decoration: none;
+										line-height: inherit;
+									}
+									background: ${category.couleur};
+									height: ${(category.nodeValue / empreinteTotale) * 100}%;
+									display: flex;
+									align-items: center;
+									justify-content: center;
+								`}
+							>
+								<Link
+									to={'/documentation/' + encodeRuleName(category.dottedName)}
+								>
+									<div
+										css={`
+											height: 100%;
+											img {
+												font-size: 120%;
+											}
+										`}
+									>
+										{category.nodeValue / empreinteTotale > 0.1
+											? emoji(category.icons)
+											: ''}
+									</div>
+								</Link>
+							</li>
+						))}
+					</ul>
+				</div>
+				<div
 					css={`
-						margin-left: 2rem;
-						width: 4rem;
-						height: 18rem;
 						border-radius: 0.3rem;
 						border: 3px solid ${color};
-						padding: 0;
+						background: #78e08f;
+						height: ${(sustainableLifeGoal[0] / empreinteTotale) * 100}%;
+						width: 4rem;
 					`}
 				>
-					{categories.map((category) => (
-						<li
-							key={category.title}
-							css={`
-								margin: 0;
-								list-style-type: none;
-								> a {
-									display: block;
-									text-decoration: none;
-									line-height: inherit;
-								}
-								background: ${category.couleur};
-								height: ${(category.nodeValue / empreinteTotale) * 100}%;
-								display: flex;
-								align-items: center;
-								justify-content: center;
-							`}
-						>
-							<Link
-								to={'/documentation/' + encodeRuleName(category.dottedName)}
-							>
-								<div
-									css={`
-										height: 100%;
-									`}
-								>
-									{emoji(category.icons)}
-								</div>
-							</Link>
-						</li>
-					))}
-				</ul>
+					{sustainableLifeGoal[1]}
+				</div>
 			</div>
 		</section>
 	)

--- a/source/sites/publicodes/chart/ClimateTargetChart.js
+++ b/source/sites/publicodes/chart/ClimateTargetChart.js
@@ -10,7 +10,8 @@ import { getRuleFromAnalysis, encodeRuleName } from 'Engine/rules'
 import Bar from './Bar'
 import emoji from 'react-easy-emoji'
 
-const sustainableLifeGoal = [2000, '2 tonnes']
+const sustainableLifeGoal = 2000 // kgCO2e
+const barWidth = '6rem'
 
 export default ({ details, color, noText, value }) => {
 	const analysis = useSelector(analysisWithDefaultsSelector),
@@ -32,33 +33,32 @@ export default ({ details, color, noText, value }) => {
 					margin: 0.6rem 0 0.1rem;
 					font-size: 140%;
 				}
+				strong {
+					font-weight: 600;
+				}
 				padding: 0;
 			`}
 		>
-			<a
-				css="color: inherit"
-				href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"
-			>
-				Comment ça ?
-			</a>
 			<div
 				css={`
 					position: relative;
 					display: flex;
 					justify-content: space-evenly;
 					align-items: flex-end;
-					height: 18rem;
+					height: 40vh;
 				`}
 			>
 				<div css="height: 100%">
 					<div css="line-height: 1.2rem">
-						{Math.round(value / 1000)} <br />
+						<strong>
+							{Math.round(value / 1000)} <br />
+						</strong>
 						tonnes
 					</div>
 					<ul
 						css={`
 							margin: 0;
-							width: 4rem;
+							width: ${barWidth};
 							height: calc(100% - 2.4rem);
 							border-radius: 0.3rem;
 							border: 3px solid ${color};
@@ -103,16 +103,57 @@ export default ({ details, color, noText, value }) => {
 						))}
 					</ul>
 				</div>
+				<div css="display: flex; justify-content: center; flex-wrap: wrap; max-width: 10rem">
+					<div
+						css={`
+							border-radius: 0.3rem;
+							border: 3px solid ${color};
+							background: #78e08f;
+							height: ${(sustainableLifeGoal / empreinteTotale) * 100}%;
+							width: ${barWidth};
+						`}
+					>
+						<strong>{sustainableLifeGoal / 1000}</strong>
+						<br />
+						tonnes
+					</div>
+				</div>
+			</div>
+			<div
+				css={`
+					display: flex;
+					justify-content: space-between;
+					margin-top: 1rem;
+				`}
+			>
 				<div
 					css={`
-						border-radius: 0.3rem;
-						border: 3px solid ${color};
-						background: #78e08f;
-						height: ${(sustainableLifeGoal[0] / empreinteTotale) * 100}%;
-						width: 4rem;
+						background: #ffffff3d;
+						border-radius: 0.6rem;
+						margin: 0 0.6rem;
+						padding: 0.4rem 1rem;
 					`}
 				>
-					{sustainableLifeGoal[1]}
+					{emoji('☝️')} Votre empreinte climat
+				</div>
+				<div
+					css={`
+						background: #ffffff3d;
+
+						border-radius: 0.6rem;
+						margin: 0 0.6rem;
+						padding: 0.4rem 1rem;
+					`}
+				>
+					<div>{emoji('🎯')} L'objectif pour être écolo.</div>
+					<div>
+						<a
+							css="color: inherit"
+							href="https://ecolab.ademe.fr/blog/général/budget-empreinte-carbone-c-est-quoi.md"
+						>
+							Comment ça ?
+						</a>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/source/sites/publicodes/chart/ClimateTargetChart.js
+++ b/source/sites/publicodes/chart/ClimateTargetChart.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { getCategories, computeEmpreinteMaximum } from './index'
+import { useSelector } from 'react-redux'
+import {
+	analysisWithDefaultsSelector,
+	parsedRulesSelector,
+} from 'Selectors/analyseSelectors'
+import { Link } from 'react-router-dom'
+import { getRuleFromAnalysis, encodeRuleName } from 'Engine/rules'
+import Bar from './Bar'
+import emoji from 'react-easy-emoji'
+
+export default ({ details, color, noText }) => {
+	const analysis = useSelector(analysisWithDefaultsSelector),
+		rules = useSelector(parsedRulesSelector)
+
+	const categories = getCategories(analysis, details, rules)
+
+	if (!categories) return null
+
+	const empreinteMaximum = computeEmpreinteMaximum(categories)
+	const empreinteTotale = categories.reduce(
+		(memo, next) => next.nodeValue + memo,
+		0
+	)
+	return (
+		<section
+			css={`
+				h2 {
+					margin: 0.6rem 0 0.1rem;
+					font-size: 140%;
+				}
+				padding: 0;
+			`}
+		>
+			<div
+				css={`
+					position: relative;
+				`}
+			>
+				<ul
+					css={`
+						margin-left: 2rem;
+						width: 4rem;
+						height: 18rem;
+						border-radius: 0.3rem;
+						border: 3px solid ${color};
+						padding: 0;
+					`}
+				>
+					{categories.map((category) => (
+						<li
+							key={category.title}
+							css={`
+								margin: 0;
+								list-style-type: none;
+								> a {
+									display: block;
+									text-decoration: none;
+									line-height: inherit;
+								}
+								background: ${category.couleur};
+								height: ${(category.nodeValue / empreinteTotale) * 100}%;
+								display: flex;
+								align-items: center;
+								justify-content: center;
+							`}
+						>
+							<Link
+								to={'/documentation/' + encodeRuleName(category.dottedName)}
+							>
+								<div
+									css={`
+										height: 100%;
+									`}
+								>
+									{emoji(category.icons)}
+								</div>
+							</Link>
+						</li>
+					))}
+				</ul>
+			</div>
+		</section>
+	)
+}

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -10,7 +10,7 @@ import Bar from './Bar'
 import { sortBy } from 'ramda'
 import { Link } from 'react-router-dom'
 
-const sortCategories = sortBy(({ nodeValue }) => -nodeValue)
+export const sortCategories = sortBy(({ nodeValue }) => -nodeValue)
 export const extractCategories = (analysis) => {
 	const getRule = getRuleFromAnalysis(analysis)
 
@@ -23,7 +23,7 @@ export const extractCategories = (analysis) => {
 	return sortCategories(categories)
 }
 
-const getCategories = (analysis, details, rules) =>
+export const getCategories = (analysis, details, rules) =>
 	analysis?.targets.length
 		? extractCategories(analysis)
 		: details &&
@@ -37,7 +37,7 @@ const getCategories = (analysis, details, rules) =>
 				})
 		  )
 
-const computeEmpreinteMaximum = (categories) =>
+export const computeEmpreinteMaximum = (categories) =>
 	categories.reduce(
 		(memo, next) => (memo.nodeValue > next.nodeValue ? memo : next),
 		-1
@@ -55,10 +55,6 @@ export default ({ details, color, noText, noAnimation }) => {
 	return (
 		<section
 			css={`
-				h2 {
-					margin: 0.6rem 0 0.1rem;
-					font-size: 140%;
-				}
 				padding: 0;
 			`}
 		>

--- a/source/sites/publicodes/chart/index.js
+++ b/source/sites/publicodes/chart/index.js
@@ -10,15 +10,6 @@ import Bar from './Bar'
 import { sortBy } from 'ramda'
 import { Link } from 'react-router-dom'
 
-const showBudget = false
-const // Rough estimate of the 2050 budget per person to stay under 2° by 2100
-	climateBudgetPerYear = 2000,
-	climateBudgetPerDay = climateBudgetPerYear / 365,
-	// Based on current share of the annual mean of 12 ton per french
-	// Source : http://ravijen.fr/?p=440
-	transportShare = 1 / 4,
-	transportClimateBudget = climateBudgetPerDay * transportShare
-
 const sortCategories = sortBy(({ nodeValue }) => -nodeValue)
 export const extractCategories = (analysis) => {
 	const getRule = getRuleFromAnalysis(analysis)
@@ -31,11 +22,9 @@ export const extractCategories = (analysis) => {
 
 	return sortCategories(categories)
 }
-export default ({ details, color, noText, noAnimation }) => {
-	const analysis = useSelector(analysisWithDefaultsSelector),
-		rules = useSelector(parsedRulesSelector)
 
-	const categories = analysis?.targets.length
+const getCategories = (analysis, details, rules) =>
+	analysis?.targets.length
 		? extractCategories(analysis)
 		: details &&
 		  sortCategories(
@@ -47,13 +36,22 @@ export default ({ details, color, noText, noAnimation }) => {
 					}
 				})
 		  )
-	if (!categories) return null
 
-	const empreinteMaximum = categories.reduce(
+const computeEmpreinteMaximum = (categories) =>
+	categories.reduce(
 		(memo, next) => (memo.nodeValue > next.nodeValue ? memo : next),
 		-1
 	).nodeValue
 
+export default ({ details, color, noText, noAnimation }) => {
+	const analysis = useSelector(analysisWithDefaultsSelector),
+		rules = useSelector(parsedRulesSelector)
+
+	const categories = getCategories(analysis, details, rules)
+
+	if (!categories) return null
+
+	const empreinteMaximum = computeEmpreinteMaximum(categories)
 	return (
 		<section
 			css={`
@@ -69,22 +67,6 @@ export default ({ details, color, noText, noAnimation }) => {
 					position: relative;
 				`}
 			>
-				<span
-					css={`
-				${!showBudget ? 'display: none' : ''}
-				height: 100%;
-				left: 0;
-				z-index: -1;
-				left: ${((transportClimateBudget * 1000) / empreinteMaximum) * 100 * 0.9}%;
-
-				width: 0px;
-				border-right: 8px dotted yellow;
-		        position: absolute;
-				margin-top: 2rem;
-				}
-					`}
-					key="budget"
-				></span>
 				<ul
 					css={`
 						margin-left: 2rem;
@@ -125,11 +107,6 @@ export default ({ details, color, noText, noAnimation }) => {
 					))}
 				</ul>
 			</div>
-			{showBudget && (
-				<span css=" background: yellow ;">
-					Budget climat 1 journée {transportClimateBudget.toFixed(1)} kg
-				</span>
-			)}
 		</section>
 	)
 }


### PR DESCRIPTION
> :hourglass_flowing_sand:  Où en est cette vieille PR ? Nous avons mis de côté le travail suite aux premières remarques. Qu'il faut reprendre dans le code.

Nouveau design pour l'écran de fin.
 
Suite à notre séminaire de cet été, où on s'est dit qu'il fallait mettre en avant l'objectif à atteindre.

Capture : 
![image](https://user-images.githubusercontent.com/1177762/104326590-2ed93780-54ea-11eb-933e-a0068b0abd66.png)
 



### A faire
- [ ] pas les bonnes hauteur de barre pour la 2t par rapport à la simulation
- [ ] rendre l'ensemble des zones de couleur de catégorie cliquables, notamment pour ceux qui sont trop petits pour un icône
- [ ] le partage de simulation marche-t-il quand il y a une simulation en cours ??
- [ ] petit bug visuel sur le contour d'en-dessous
- [ ] intégrer un petit texte "cela va partager seulement le contenu de cette page" #80 
"l'objectif pour maintenir la planète habitable" ?
- [ ] répondre à https://github.com/betagouv/ecolab-data/issues/886

Remarques sur le fond : 
- enlever "pour être écolo", juste "l"objectif" ou "notre objectif". 
- mieux faire ressortir les postes de conso avec un texte en backup de l'icône : 50% de la largeur pour la barre verticale actuelle ?

### Bonus : 
- [ ] faire une flèche de l'empreinte à gauche à celle de droite, avec éventuellement un texte "le plus vite possible"
- [ ] faut-il un titre ? 
- [ ] réserver le dégradé de couleur pour un contour du résultat, plus subtile que le fond entier d'aujourd'hui qui perturbe la lecture ?