### PR TITLE
Passage à un tri décroissant pour les actions du mode autonome

### DIFF
--- a/source/sites/publicodes/Actions.js
+++ b/source/sites/publicodes/Actions.js
@@ -65,7 +65,7 @@ const ActionList = animated(({}) => {
 	const rules = useSelector((state) => state.rules)
 	const flatActions = rules['actions']
 
-	const [radical, setRadical] = useState(false)
+	const [radical, setRadical] = useState(true)
 
 	const simulation = useSelector((state) => state.simulation)
 


### PR DESCRIPTION
Le mode guidé permet de voir un programme progressif, je pense qu'il est
bien de classer le mode autonome inversement par défaut.