### PR TITLE
:bug: Mauvais composant pour l'URL vie privée

### DIFF
--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -114,7 +114,7 @@ const Router = ({}) => {
 					<Route path="/contribuer/:input?" component={Contribution} />
 					<Route path="/à-propos" component={About} />
 					<Route path="/partenaires" component={Partenaires} />
-					<Route path="/vie-privée" component={About} />
+					<Route path="/vie-privée" component={Privacy} />
 					<Route path="/nouveautés" component={News} />
 					<Route path="/conférence/:room?">
 						<Suspense fallback="Chargement">

--- a/source/sites/publicodes/about.md
+++ b/source/sites/publicodes/about.md
@@ -20,7 +20,7 @@ Le simulateur est amélioré en continu.
 
 Nous collectons des données anonymisées uniquement pour améliorer ce simulateur.
 
-[🍪 En savoir plus](https://datagir.ademe.fr/cookies)
+[🍪 En savoir plus](/vie-privée)
 
 ## Comment intégrer ce simulateur dans votre site ?
 


### PR DESCRIPTION
@martinregner le lien "vie privée" faisait référence à un composant pas branché sur l'URL /vie-privée, par erreur. J'ai corrigé ça en voyant ton commit :) 