### PR TITLE
Revert "Gen image fin"

### DIFF
--- a/source/sites/publicodes/Fin.js
+++ b/source/sites/publicodes/Fin.js
@@ -77,6 +77,7 @@ const AnimatedDiv = animated(({ score, value, details, headlessMode }) => {
 		textColor = findContrastedTextColor(backgroundColor, true),
 		roundedValue = Math.round(value / 1000),
 		shareImage =
+			'https://aejkrqosjq.cloudimg.io/v7/' +
 			window.location.origin +
 			'/.netlify/functions/ending-screenshot?pageToScreenshot=' +
 			window.location


### PR DESCRIPTION
Reverts datagir/nosgestesclimat-site#299

Je reviens en arrière, car ça ne fonctionne pas. Le serveur de cache d'image semble bien être nécessaire, sans que je ne sache trop pour quoi. Sûrement une question de délai. Peut-être que le premier appel du réseau social lance la mise en cache, puis l'appel vers l'image est plus rapide ?