### PR TITLE
Améliorations de la visualisation des résultats pendant le test

### DIFF
--- a/source/components/ui/AnimatedTargetValue.css
+++ b/source/components/ui/AnimatedTargetValue.css
@@ -3,7 +3,7 @@
 }
 
 .evaporate {
-	font-size: 80%;
+	font-size: 100%;
 	display: block;
 	position: absolute;
 	right: 0;

--- a/source/components/ui/AnimatedTargetValue.tsx
+++ b/source/components/ui/AnimatedTargetValue.tsx
@@ -10,23 +10,22 @@ type AnimatedTargetValueProps = {
 	children?: React.ReactNode
 }
 
-const formatDifference = (difference: number, language: string) => {
+const formatDifference = (difference: number, unit: string) => {
 	const prefix = difference > 0 ? '+' : ''
-	return prefix + formatValue(difference, { displayedUnit: '€', language })
+	return (
+		prefix +
+		difference.toLocaleString('fr-FR', { maximumSignificantDigits: 1 }) +
+		' ' +
+		unit
+	)
 }
 
 export default function AnimatedTargetValue({
 	value,
-	children
+	children,
+	unit,
 }: AnimatedTargetValueProps) {
 	const previousValue = useRef<number>()
-	const { language } = useTranslation().i18n
-
-	// We don't want to show the animated if the difference comes from a change in the unit
-	const currentUnit = useSelector(
-		(state: RootState) => state?.simulation?.targetUnit
-	)
-	const previousUnit = useRef(currentUnit)
 
 	const difference =
 		previousValue.current === value || (value && Number.isNaN(value))
@@ -34,26 +33,24 @@ export default function AnimatedTargetValue({
 			: (value || 0) - (previousValue.current || 0)
 	const shouldDisplayDifference =
 		difference != null &&
-		previousUnit.current === currentUnit &&
-		Math.abs(difference) > 1 &&
 		previousValue.current != null &&
 		previousValue.current != 0 &&
 		value != null
 
+	console.log(shouldDisplayDifference, value, previousValue.current)
 	previousValue.current = value
-	previousUnit.current = currentUnit
 
 	return (
 		<>
 			<span className="Rule-value">
-				{shouldDisplayDifference && difference !== null && (
+				{shouldDisplayDifference && (
 					<Evaporate
 						style={{
 							color: difference > 0 ? 'chartreuse' : 'red',
-							pointerEvents: 'none'
+							pointerEvents: 'none',
 						}}
 					>
-						{formatDifference(difference, language)}
+						{formatDifference(difference, unit)}
 					</Evaporate>
 				)}{' '}
 				{children}
@@ -64,7 +61,7 @@ export default function AnimatedTargetValue({
 
 const Evaporate = React.memo(function Evaporate({
 	children,
-	style
+	style,
 }: {
 	children: string
 	style: React.CSSProperties

--- a/source/sites/publicodes/HumanWeight.js
+++ b/source/sites/publicodes/HumanWeight.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { useSelector } from 'react-redux'
+import AnimatedTargetValue from '../../components/ui/AnimatedTargetValue'
 
 export const humanWeight = (possiblyNegativeValue, concise = false) => {
 	const v = Math.abs(possiblyNegativeValue)
@@ -19,10 +20,10 @@ export const humanWeight = (possiblyNegativeValue, concise = false) => {
 				? raw.toLocaleString('fr-FR', { maximumSignificantDigits: 2 })
 				: Math.round(raw).toLocaleString('fr-FR')
 
-	return [value, unit]
+	return [value, unit, raw]
 }
 export default ({ nodeValue, overrideValue }) => {
-	const [value, unit] = humanWeight(nodeValue)
+	const [value, unit, raw] = humanWeight(nodeValue)
 	return (
 		<span
 			css={`
@@ -32,6 +33,7 @@ export default ({ nodeValue, overrideValue }) => {
 				align-items: baseline;
 			`}
 		>
+			<AnimatedTargetValue value={raw} unit={unit} />
 			<strong
 				classname="humanvalue"
 				css={`


### PR DESCRIPTION
- [ ] visualisation de la valeur bilan à la Mario
Pas convaincu : il faudrait plutôt visualiser l'écart par rapport à la simulation avec les étapes validées. Donc par rapport à la moyenne en 1ère simulation, puis par rapport à la situation précédente en cas de retour sur questions. 

- [ ] animation des barres du graphique (AnimatePresence)
- [ ] simplification du graphique, qui sera plus complet sur /fin 
- [ ] ou alors trouver un moyen de le mettre dans la barre de simul, le seul but étant de montrer une catégorie par rapport à une autre, appelant à un clic pour ouvrir l'écran de fin dans un mode "pas fini" ?
- [ ] graphe de sous-catégorie : au clic, montrer le %