### PR TITLE
:bug: Nombre >= 10 s'affiche pas dans la mosaique iPhone

### DIFF
--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -72,6 +72,7 @@ export default function NumberedMosaic({
 										type="number"
 										css={`
 											width: 1.5rem;
+											padding: 0; /* Necessary for iPhone Safari 7-12 at least */
 											height: 1.5rem;
 											font-size: 100%;
 											color: var(--darkColor);


### PR DESCRIPTION
Fixes datagir/nosgestesclimat/issues/1284
