### PR TITLE
Caractères interdits nom des sondages

### DIFF
--- a/source/sites/publicodes/conference/NamingBlock.tsx
+++ b/source/sites/publicodes/conference/NamingBlock.tsx
@@ -5,7 +5,7 @@ import { generateRoomName } from './utils'
 export default ({ newRoom, setNewRoom }) => {
 	const inputRef = useRef(null)
 	const [showInvalidMessage, setShowInvalidMessage] = useState(true)
-	const specialCharaters = /[!@#$%^&*()_+\=\[\]{};':"\\|,.<>\/?]+/
+	const specialCharaters = /[!@#$%&*()+\=\[\]{};':"\\|,.<>\/?]+/
 	return (
 		<>
 			<label>


### PR DESCRIPTION
On autorise désormais les ^et _ dans les noms de sondages pour répondre à certaines demandes (ping @martinregner)