### PR TITLE
formatvalue pour les valeurs par défaut

### DIFF
--- a/source/components/conversation/Input.tsx
+++ b/source/components/conversation/Input.tsx
@@ -62,9 +62,9 @@ export default function Input({
 								)
 							}}
 							autoComplete="off"
-							{...{
-								[missing ? 'placeholder' : 'value']: formatValue(value) ?? '',
-							}}
+							{...(missing
+								? { placeholder: value ? formatValue(value) : '' }
+								: { value: value ?? '' })}
 						/>
 						<label htmlFor={id}>
 							<span className="suffix">&nbsp;{unité}</span>

--- a/source/components/conversation/Input.tsx
+++ b/source/components/conversation/Input.tsx
@@ -62,7 +62,9 @@ export default function Input({
 								)
 							}}
 							autoComplete="off"
-							{...{ [missing ? 'placeholder' : 'value']: value ?? '' }}
+							{...{
+								[missing ? 'placeholder' : 'value']: formatValue(value) ?? '',
+							}}
 						/>
 						<label htmlFor={id}>
 							<span className="suffix">&nbsp;{unité}</span>


### PR DESCRIPTION
Afin de formater les valeurs par défaut des inputs lorsqu'elles sont calculées.

Avant:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/55186402/177396301-e7d5eef2-8fec-43b1-8e6d-348e5c727fa3.png">
