### PR TITLE
Ré-introduction du bouton "Je ne sais pas" dans les mosaïques

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -136,7 +136,7 @@ export default function Conversation({
 	}, [dispatch, currentQuestion, previousAnswers, unfoldedStep, objectifs])
 
 	useEffect(() => {
-		// This hook enables top set the focus on the question span and not on the "Suivant" button when going to next question
+		// This hook enables to set the focus on the question span and not on the "Suivant" button when going to next question
 		const questionElement =
 			rules[currentQuestion] &&
 			document.getElementById('id-question-' + title(rules[currentQuestion]))

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -95,11 +95,6 @@ export default function Conversation({
 			? sortedQuestions[0]
 			: unfoldedStep || sortedQuestions[0]
 
-	const currentQuestionIsAnswered =
-		currentQuestion && isMosaic(currentQuestion)
-			? true
-			: situation[currentQuestion] != null
-
 	const [finder, setFinder] = useState(false)
 	const tutorials = useSelector((state) => state.tutorials)
 
@@ -167,6 +162,26 @@ export default function Conversation({
 				)
 				.map(([dottedName]) => dottedName)
 		: [currentQuestion]
+
+	const isAnsweredMosaic =
+		currentQuestion &&
+		isMosaic(currentQuestion) &&
+		questionsToSubmit
+			.map((question) => situation[question] != null)
+			.some((bool) => bool === true)
+
+	const currentQuestionIsAnswered = isAnsweredMosaic
+		? true
+		: situation[currentQuestion] != null
+
+	useEffect(() => {
+		// This hook enables to set all the checkbox of a mosaic to false when once one is checked
+		if (isAnsweredMosaic && mosaicQuestion?.options?.defaultsToFalse) {
+			questionsToSubmit.map((question) =>
+				dispatch(updateSituation(question, situation[question] || 'non'))
+			)
+		}
+	}, [currentQuestion, isAnsweredMosaic])
 
 	const currentQuestionIndex = previousAnswers.findIndex(
 			(a) => a === unfoldedStep
@@ -390,6 +405,31 @@ export default function Conversation({
 								<Trans>Suivant</Trans> →
 							</span>
 						</button>
+					) : isMosaic(currentQuestion) ? (
+						<div>
+							<button
+								onClick={() => {
+									tracker.push([
+										'trackEvent',
+										'je ne sais pas',
+										currentQuestion,
+									])
+									setDefault()
+								}}
+								type="button"
+								className="ui__ simple small push-right button"
+							>
+								<Trans>Je ne sais pas</Trans> →
+							</button>
+							<button
+								className="ui__ plain small button"
+								onClick={() => submit('accept')}
+							>
+								<span className="text">
+									<Trans>Suivant</Trans> →
+								</span>
+							</button>
+						</div>
 					) : (
 						<button
 							onClick={() => {

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -199,6 +199,8 @@ export default function Conversation({
 				: previousAnswers[currentQuestionIndex - 1]
 
 	const submit = (source: string) => {
+		// This piece of code enables to set all the checkbox of a mosaic to false when "Next" button is pressed (chen the question is submitted)
+		// It's important in case of someone arrives at the mosaic question, does not select anything and wants to submit "nothing".
 		if (mosaicQuestion?.options?.defaultsToFalse) {
 			questionsToSubmit.map((question) =>
 				dispatch(updateSituation(question, situation[question] || 'non'))

--- a/source/components/conversation/mosaicQuestions.ts
+++ b/source/components/conversation/mosaicQuestions.ts
@@ -157,6 +157,7 @@ Vos consommations de boissons chaudes pour une semaine type. Un café par jour ?
 	},
 	{
 		dottedName: 'alimentation . déchets . gestes',
+		options: { defaultsToFalse: true },
 		question:
 			'Quels éco-gestes mettez-vous en place pour réduire vos déchets ?',
 		isApplicable: (dottedName: DottedName) =>


### PR DESCRIPTION
**Pb actuel :** Aujourd'hui, au niveau d'une mosaïque, le bouton suivant apparait directement. Pour les mosaïques "select" Les valeurs par défaut sont bien pré-sélectionnées mais au clic sur suivant, elles sont mises à 0 si defaulttofalse est activé -> ce qui est attendu car rien n'est coché ! Seul échappe permet d'ajouter les valeurs par défaut à la situation mais on pourrait aussi supposé qu'une personne souhaite répondre rapidement ou clique sur suivant trop vite.

**Solution :** Je propose ici d'ajouter le bouton "je ne sais pas" qui permet de valider les valeurs par défaut (certes non explicite pour l'utilisateur) qui disparait si l'une des cases est coché. Le bouton suivant ne valide toujours "rien" s'il est cliqué en premier. Si une réponse est cochée, toutes les valeurs par défaut deviennent false