### PR TITLE
Notification 'invalide' pour filtrer les inputs

### DIFF
--- a/source/components/Notifications.tsx
+++ b/source/components/Notifications.tsx
@@ -1,6 +1,6 @@
 import { hideNotification } from 'Actions/actions'
 import animate from 'Components/ui/animate'
-import { useEngine, useInversionFail } from 'Components/utils/EngineContext'
+import { useEngine } from 'Components/utils/EngineContext'
 import Engine, { RuleNode } from 'publicodes'
 import emoji from 'react-easy-emoji'
 import { useTranslation } from 'react-i18next'
@@ -18,7 +18,7 @@ import { ScrollToElement } from './utils/Scroll'
 type Notification = {
 	dottedName: RuleNode['dottedName']
 	description: RuleNode['rawNode']['description']
-	sévérité: 'avertissement' | 'information'
+	sévérité: 'avertissement' | 'information' | 'invalide'
 }
 
 export function getNotifications(engine: Engine) {
@@ -34,35 +34,37 @@ export function getNotifications(engine: Engine) {
 			description,
 		}))
 }
-export default function Notifications({ currentQuestion }) {
-	const { t } = useTranslation()
-	const engine = useEngine()
-	const inversionFail = useInversionFail()
-	const hiddenNotifications = useSelector(
-		(state: RootState) => state.simulation?.hiddenNotifications
-	)
-	const dispatch = useDispatch()
 
-	const messages: Array<Notification> = inversionFail
-		? [
-				{
-					dottedName: 'inversion fail',
-					description: t(
-						'simulateurs.inversionFail',
-						'Le montant saisi abouti à un résultat impossible. Cela est dû à un effet de seuil dans le calcul des cotisations.\n\nNous vous invitons à réessayer en modifiant légèrement le montant renseigné (quelques euros de plus par exemple).'
-					),
-					sévérité: 'avertissement',
-				},
-		  ]
-		: (getNotifications(engine) as Array<Notification>)
+export function getCurrentNotification(
+	engine,
+	currentQuestion: RuleNode['dottedName']
+) {
+	const messages: Array<Notification> = getNotifications(
+		engine
+	) as Array<Notification>
+
 	if (!messages?.length) return null
-
 	// Here we filter notifications to not display them out of context
 	// but this supposes that notifications would be well placed in termes of namespaces
 	// for now we're using only one notifcation, so that's the behavior we want
 	const filteredMessages = messages.filter(({ dottedName }) =>
 		parentName(currentQuestion).includes(parentName(dottedName))
 	)
+	return filteredMessages
+}
+
+export default function Notifications({ currentQuestion }) {
+	const { t } = useTranslation()
+	const hiddenNotifications = useSelector(
+		(state: RootState) => state.simulation?.hiddenNotifications
+	)
+	const engine = useEngine()
+
+	const dispatch = useDispatch()
+
+	const filteredMessages = getCurrentNotification(engine, currentQuestion)
+
+	if (!filteredMessages) return null
 
 	return (
 		<div id="notificationsBlock">
@@ -72,7 +74,13 @@ export default function Notifications({ currentQuestion }) {
 						<animate.fromTop key={dottedName}>
 							<li>
 								<div role="alert" className="notification">
-									{emoji(sévérité == 'avertissement' ? '⚠️' : '💁🏻')}
+									{emoji(
+										sévérité == 'avertissement'
+											? '⚠️'
+											: 'invalide'
+											? '🚫'
+											: '💁🏻'
+									)}
 									<div className="notificationText ui__ card">
 										<Markdown>{description}</Markdown>
 										<button

--- a/source/components/Notifications.tsx
+++ b/source/components/Notifications.tsx
@@ -83,13 +83,15 @@ export default function Notifications({ currentQuestion }) {
 									)}
 									<div className="notificationText ui__ card">
 										<Markdown>{description}</Markdown>
-										<button
-											className="hide"
-											aria-label="close"
-											onClick={() => dispatch(hideNotification(dottedName))}
-										>
-											×
-										</button>
+										{sévérité !== 'invalide' && (
+											<button
+												className="hide"
+												aria-label="close"
+												onClick={() => dispatch(hideNotification(dottedName))}
+											>
+												×
+											</button>
+										)}
 									</div>
 								</div>
 							</li>

--- a/source/components/Notifications.tsx
+++ b/source/components/Notifications.tsx
@@ -77,7 +77,7 @@ export default function Notifications({ currentQuestion }) {
 									{emoji(
 										sévérité == 'avertissement'
 											? '⚠️'
-											: 'invalide'
+											: sévérité == 'invalide'
 											? '🚫'
 											: '💁🏻'
 									)}

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -203,13 +203,9 @@ export default function Conversation({
 		// we also want it work for questions with multiple notifications
 		const questionMatches = questionsToSubmit.map((question) => {
 			const notifications = getCurrentNotification(engine, question)
-			const notifMatches = notifications.map(({ sévérité }) => {
-				if (sévérité === 'invalide') return false
-				else return true
-			})
-			return notifMatches.every((bool) => bool === true)
+			return !notifications.some(({ sévérité }) => sévérité === 'invalide')
 		})
-		return questionMatches.every((bool) => bool === true)
+		return questionMatches.every(Boolean)
 	}
 
 	const submit = (source: string) => {

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -7,7 +7,7 @@ import RuleInput, {
 	isMosaic,
 	RuleInputProps,
 } from 'Components/conversation/RuleInput'
-import Notifications from 'Components/Notifications'
+import Notifications, { getCurrentNotification } from 'Components/Notifications'
 import { EngineContext } from 'Components/utils/EngineContext'
 import { useNextQuestions } from 'Components/utils/useNextQuestion'
 import { TrackerContext } from 'Components/utils/withTracker'
@@ -198,6 +198,20 @@ export default function Conversation({
 						)
 				: previousAnswers[currentQuestionIndex - 1]
 
+	const isValidInput = (questionsToSubmit) => {
+		// we want this validation function to work for mosaic questions (we check that all the questions anwsers of a mosaic are valid)
+		// we also want it work for questions with multiple notifications
+		const questionMatches = questionsToSubmit.map((question) => {
+			const notifications = getCurrentNotification(engine, question)
+			const notifMatches = notifications.map(({ sévérité }) => {
+				if (sévérité === 'invalide') return false
+				else return true
+			})
+			return notifMatches.every((bool) => bool === true)
+		})
+		return questionMatches.every((bool) => bool === true)
+	}
+
 	const submit = (source: string) => {
 		// This piece of code enables to set all the checkbox of a mosaic to false when "Next" button is pressed (chen the question is submitted)
 		// It's important in case of someone arrives at the mosaic question, does not select anything and wants to submit "nothing".
@@ -207,14 +221,18 @@ export default function Conversation({
 			)
 		}
 
-		questionsToSubmit.map((question) =>
+		// we don't check question validation status in the same map as the dispatch because we want all answers in mosaic question
+		// to be valid before any dispatch
+		if (!isValidInput(questionsToSubmit)) return null
+
+		questionsToSubmit.map((question) => {
 			dispatch({
 				type: 'STEP_ACTION',
 				name: 'fold',
 				step: question,
 				source,
 			})
-		)
+		})
 	}
 	const setDefault = () =>
 		// TODO: Skiping a question shouldn't be equivalent to answering the

--- a/source/components/utils/EngineContext.tsx
+++ b/source/components/utils/EngineContext.tsx
@@ -59,6 +59,3 @@ export function SituationProvider({
 		<EngineContext.Provider value={engine}>{children}</EngineContext.Provider>
 	)
 }
-export function useInversionFail() {
-	return useContext(EngineContext).inversionFail()
-}


### PR DESCRIPTION
Pour faire suite à #601 

Démo : https://notification-invalid-input-value--nosgestesclimat.netlify.app/?PR=1454

Je remets le dernier commentaire de la PR ici :

 Je mets en ligne cette PR car elle résout des problèmes majeurs pour l'aide à la saisie des km et permet d'être plus rigoureux sur les inputs des questions de la conversation, sans l'introduction de filtre pour ces inputs pour le moment.

> La gestion de l'input de la conversation est assez compliquée car on souhaite que le submit reste général.
> Plusieurs solutions envisagées pour vérifier l'input et permettre ou non sa validation :
>
> - Une fonction de validation définie dans Input et appelée et exécutée dans le submit de Conversation (en affichant un warning sur l'input)
> - Une variable dans le state initialisée à true qui devient false si la valeur n'est pas valide et donc empêche la validation du submit de Conversation (en affichant un warning sur l'input). A noter que cette variable doit etre remis à true à partir du moment ou l'input est valide et ce pour toutes les questions
> - Gérer les validations directement dans la situation
> - Utiliser le composant Notification déjà en place pour désactiver le submit si une notification de sévérité "invalide" est déclenchée

- [x] Mise en place de la notification invalide
- [x] Pas de validation si notification affichée
- [ ] Review @laem
- [x] Pb emoji des autres notifications
- [x] On peut toujours ajouter des valeurs négatives
- [ ] Faire une issue pour gérer le pb côté publicodes
- [x] wording

A noter que le changement dans l'input affecte tout de même la situation : un personne qui répond 0 au nombre de personnes dans la voiture, qui ne comprend pas pourquoi le bouton suivant ne fonctionne pas, clique sur un autre onglet du menu puis revient sur le test verra sa question validée
