### PR TITLE
Améliorations page stats

### DIFF
--- a/source/components/stats/StatsContent.js
+++ b/source/components/stats/StatsContent.js
@@ -27,6 +27,7 @@ import Chart from './content/Chart'
 import DurationChart from './content/DurationChart'
 import DurationFigures from './content/DurationFigures'
 import KmFigures from './content/KmFigures'
+import ScoreFromURL from './content/ScoreFromURL'
 // import Loader from './applications/Loader'
 
 const Wrapper = styled.div`
@@ -77,12 +78,13 @@ export default function Data(props) {
 			allTime ? (
 				<>
 					<Section>
+						<ScoreFromURL pages={pages} />
 						<Section.Title>Stats générales</Section.Title>
 						<Wrapper>
 							<Evolution
 								period={period.value}
 								reference={reference.value}
-								pages={pages.value}
+								pages={pages}
 								allTime={allTime.value}
 								simulations={simulations}
 							/>

--- a/source/components/stats/StatsContent.js
+++ b/source/components/stats/StatsContent.js
@@ -26,6 +26,7 @@ import Sources from './content/Sources'
 import Chart from './content/Chart'
 import DurationChart from './content/DurationChart'
 import DurationFigures from './content/DurationFigures'
+import IframeFigures from './content/IframeFigures'
 import KmFigures from './content/KmFigures'
 import ScoreFromURL from './content/ScoreFromURL'
 // import Loader from './applications/Loader'
@@ -78,7 +79,6 @@ export default function Data(props) {
 			allTime ? (
 				<>
 					<Section>
-						<ScoreFromURL pages={pages} />
 						<Section.Title>Stats générales</Section.Title>
 						<Wrapper>
 							<Evolution
@@ -105,6 +105,24 @@ export default function Data(props) {
 							socials={socials}
 							keywords={keywords}
 						/>
+					</Section>
+					<Section>
+						<Section.Title>Intégrations et Iframes</Section.Title>
+						<Section.Intro>
+							<summary>En savoir plus</summary>
+							Les intégrations en iframe sont détéctées via le paramètre
+							'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé
+							le&nbsp;<a href="./diffuser">script dédié</a>. Ainsi, les visites
+							via les iframes d'intégrateurs qui n'ont pas utilisé ce script
+							sont dispersées dans les visites générales de Nos Gestes Climat.
+							Afin de tenter d'estimer le taux d'affichage en iframe, nous avons
+							fait l'hypothèse que 60% (valeur arbitraire) des visites achevées
+							dès la page d'acceuil sont des iframes.{' '}
+							<i>(Données valables pour les 30 derniers jours)</i>
+						</Section.Intro>
+						<Wrapper>
+							<IframeFigures pages={pages} />
+						</Wrapper>
 					</Section>
 					<Section>
 						<Section.Title>Durée des visites</Section.Title>

--- a/source/components/stats/StatsContent.js
+++ b/source/components/stats/StatsContent.js
@@ -15,6 +15,7 @@ import {
 	usePeriod,
 	useReference,
 	usePages,
+	useActivePages,
 	useAllTime,
 	useKmHelp,
 	useSimulationsfromKmHelp,
@@ -60,6 +61,7 @@ export default function Data(props) {
 	const { data: period } = usePeriod()
 	const { data: reference } = useReference()
 	const { data: pages } = usePages()
+	const { data: activePages } = useActivePages()
 	const { data: allTime } = useAllTime()
 	const { data: kmhelp } = useKmHelp()
 	const { data: simulationsfromhelp } = useSimulationsfromKmHelp()
@@ -115,13 +117,12 @@ export default function Data(props) {
 							le&nbsp;<a href="./diffuser">script dédié</a>. Ainsi, les visites
 							via les iframes d'intégrateurs qui n'ont pas utilisé ce script
 							sont dispersées dans les visites générales de Nos Gestes Climat.
-							Afin de tenter d'estimer le taux d'affichage en iframe, nous avons
-							fait l'hypothèse que 60% (valeur arbitraire) des visites achevées
-							dès la page d'acceuil sont des iframes.{' '}
+							Dans l'attente de chiffres plus précis, ce taux est donc
+							potentiellement sous-estimé par rapport à la réalité.
 							<i>(Données valables pour les 30 derniers jours)</i>
 						</Section.Intro>
 						<Wrapper>
-							<IframeFigures pages={pages} />
+							<IframeFigures pages={pages} activePages={activePages} />
 						</Wrapper>
 					</Section>
 					<Section>

--- a/source/components/stats/StatsContent.js
+++ b/source/components/stats/StatsContent.js
@@ -14,8 +14,9 @@ import {
 	useKeywords,
 	usePeriod,
 	useReference,
+	useEntryPages,
+	useActiveEntryPages,
 	usePages,
-	useActivePages,
 	useAllTime,
 	useKmHelp,
 	useSimulationsfromKmHelp,
@@ -60,8 +61,9 @@ export default function Data(props) {
 	const { data: keywords } = useKeywords()
 	const { data: period } = usePeriod()
 	const { data: reference } = useReference()
+	const { data: entryPages } = useEntryPages()
+	const { data: activeEntryPages } = useActiveEntryPages()
 	const { data: pages } = usePages()
-	const { data: activePages } = useActivePages()
 	const { data: allTime } = useAllTime()
 	const { data: kmhelp } = useKmHelp()
 	const { data: simulationsfromhelp } = useSimulationsfromKmHelp()
@@ -78,6 +80,8 @@ export default function Data(props) {
 			period &&
 			reference &&
 			pages &&
+			activeEntryPages &&
+			entryPages &&
 			allTime ? (
 				<>
 					<Section>
@@ -86,7 +90,6 @@ export default function Data(props) {
 							<Evolution
 								period={period.value}
 								reference={reference.value}
-								pages={pages}
 								allTime={allTime.value}
 								simulations={simulations}
 							/>
@@ -124,7 +127,10 @@ export default function Data(props) {
 							</p>
 						</Section.Intro>
 						<Wrapper>
-							<IframeFigures pages={pages} activePages={activePages} />
+							<IframeFigures
+								pages={entryPages}
+								activePages={activeEntryPages}
+							/>
 						</Wrapper>
 					</Section>
 					<Section>

--- a/source/components/stats/StatsContent.js
+++ b/source/components/stats/StatsContent.js
@@ -112,14 +112,16 @@ export default function Data(props) {
 						<Section.Title>Intégrations et Iframes</Section.Title>
 						<Section.Intro>
 							<summary>En savoir plus</summary>
-							Les intégrations en iframe sont détéctées via le paramètre
-							'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé
-							le&nbsp;<a href="./diffuser">script dédié</a>. Ainsi, les visites
-							via les iframes d'intégrateurs qui n'ont pas utilisé ce script
-							sont dispersées dans les visites générales de Nos Gestes Climat.
-							Dans l'attente de chiffres plus précis, ce taux est donc
-							potentiellement sous-estimé par rapport à la réalité.
-							<i>(Données valables pour les 30 derniers jours)</i>
+							<p>
+								Les intégrations en iframe sont détéctées via le paramètre
+								'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé
+								le&nbsp;<a href="./diffuser">script dédié</a>. Ainsi, les
+								visites via les iframes d'intégrateurs qui n'ont pas utilisé ce
+								script sont dispersées dans les visites générales de Nos Gestes
+								Climat. Dans l'attente de chiffres plus précis, ce taux est donc
+								potentiellement sous-estimé par rapport à la réalité.
+								<i>(Données valables pour les 30 derniers jours)</i>
+							</p>
 						</Section.Intro>
 						<Wrapper>
 							<IframeFigures pages={pages} activePages={activePages} />
@@ -129,16 +131,45 @@ export default function Data(props) {
 						<Section.Title>Durée des visites</Section.Title>
 						<Section.Intro>
 							<summary>En savoir plus</summary>
-							Cette section est générée à partir des visites des 60 derniers
-							jours. Les visites dont le temps passé sur le site est inférieur à
-							1 minute ont été écartées. Pour éviter le biais de l'iframe qui
-							peut générer des visiteurs inactifs dans les statistiques, le
-							temps moyen sur le site a été calculé à partir des visites actives
-							(l'utilisateur a cliqué sur "Faire le test").
+							<p>
+								Cette section est générée à partir des visites des 60 derniers
+								jours. Les visites dont le temps passé sur le site est inférieur
+								à 1 minute ont été écartées. Pour éviter le biais de l'iframe
+								qui peut générer des visiteurs inactifs dans les statistiques,
+								le temps moyen sur le site a été calculé à partir des visites
+								actives (l'utilisateur a cliqué sur "Faire le test").
+							</p>
 						</Section.Intro>
 						<Wrapper>
 							<DurationFigures avgduration={avgduration} />
 							{duration && <DurationChart duration={duration} />}
+						</Wrapper>
+					</Section>
+					<Section>
+						<Section.Title>Score de nos utilisateurs</Section.Title>
+						<Section.Intro>
+							<summary>En savoir plus</summary>
+							<p>
+								Bien sûr, nous ne collectons pas{' '}
+								<a href="/vie-priv%C3%A9e">les données utlisateurs</a>.
+								Néanmoins, le score total ainsi que l'empreinte par catégorie
+								est présente dans l'URL de fin de test. Dans cette section, nous
+								agrégeons cees informations pour avoir une idée de l'empreinte
+								carbone moyenne de nos utilisateurs et de distribution du score
+								afin d'analyser ces résultats dans le contexte des évolutions du
+								modèle.
+							</p>{' '}
+							<p>
+								L'objectif ici n'est pas d'évaluer l'empreinte carbone des
+								Français : à priori, les utilisateurs du tests de sont pas
+								représentatifs des Français. De plus, ces données peuvent être
+								biaisées par des utilisateurs qui reviendraient à plusieurs
+								reprises sur la page de fin, en changeant ses réponses au test
+								(ce qui crée de nouveaux url de fin).
+							</p>
+						</Section.Intro>
+						<Wrapper>
+							<ScoreFromURL pages={pages} />
 						</Wrapper>
 					</Section>
 					<Section>

--- a/source/components/stats/content/Chart.js
+++ b/source/components/stats/content/Chart.js
@@ -73,7 +73,7 @@ export default function AreaWeekly(props) {
 						/>
 						<YAxis
 							tickFormatter={(tick) =>
-								tick.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+								tick.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')
 							}
 						/>
 						<Tooltip content={<CustomTooltip period={props.period} />} />

--- a/source/components/stats/content/Evolution.js
+++ b/source/components/stats/content/Evolution.js
@@ -70,7 +70,7 @@ export default function Evolution(props) {
 		<Wrapper>
 			<TopBlock>
 				<BigNumber>
-					{props.allTime.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}
+					{props.allTime.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}
 				</BigNumber>{' '}
 				&nbsp;visites depuis le lancement
 			</TopBlock>
@@ -87,7 +87,7 @@ export default function Evolution(props) {
 					<Number>
 						{(simulations?.nb_visits + baseSimulations)
 							.toString()
-							.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}
+							.replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}
 					</Number>{' '}
 					simulations terminées depuis le lancement
 				</Block>

--- a/source/components/stats/content/Evolution.js
+++ b/source/components/stats/content/Evolution.js
@@ -66,6 +66,11 @@ export default function Evolution(props) {
 	// We didn't track this stat at the beginning so we're guessing based on todays average completion
 	const baseSimulations = 32015
 	const simulations = props.simulations
+
+	const [iframes, activeIframes] = props.pages && getIframeRate(props.pages)
+
+	// console.log(iframes, activeIframes)
+
 	return (
 		<Wrapper>
 			<TopBlock>
@@ -94,4 +99,38 @@ export default function Evolution(props) {
 			</BlockWrapper>
 		</Wrapper>
 	)
+}
+
+// for iframe rate we consider as iframe url pages which include 'iframe' and inactive landing pages
+const getIframeRate = (pages) => {
+	const totalPages = pages.reduce((acc, cur) => acc + cur.entry_nb_visits, 0)
+
+	const iframePages = pages.filter((page) => page.label.includes('iframe'))
+
+	const iframeLandingPages = pages.filter(
+		(page) => page.label.includes('iframe') && page.label.includes('index')
+	)
+
+	const totalIframe = iframePages.reduce(
+		(acc, cur) => acc + cur.entry_nb_visits,
+		0
+	)
+
+	const totalExitIframe = iframeLandingPages.reduce(
+		(acc, cur) => acc + cur.exit_nb_visits,
+		0
+	)
+	const totalActiveIframe = totalIframe - totalExitIframe
+
+	const landingPage = pages.find((obj) => obj.label === '/index')
+
+	const exitLandingPage = landingPage.exit_nb_visits
+
+	const approximatedTotalIframes = exitLandingPage + totalIframe
+
+	const iframes = (approximatedTotalIframes / totalPages) * 100
+
+	const activeIframes = (totalActiveIframe / approximatedTotalIframes) * 100
+
+	return [iframes, activeIframes]
 }

--- a/source/components/stats/content/Evolution.js
+++ b/source/components/stats/content/Evolution.js
@@ -67,10 +67,6 @@ export default function Evolution(props) {
 	const baseSimulations = 32015
 	const simulations = props.simulations
 
-	const [iframes, activeIframes] = props.pages && getIframeRate(props.pages)
-
-	// console.log(iframes, activeIframes)
-
 	return (
 		<Wrapper>
 			<TopBlock>
@@ -99,38 +95,4 @@ export default function Evolution(props) {
 			</BlockWrapper>
 		</Wrapper>
 	)
-}
-
-// for iframe rate we consider as iframe url pages which include 'iframe' and inactive landing pages
-const getIframeRate = (pages) => {
-	const totalPages = pages.reduce((acc, cur) => acc + cur.entry_nb_visits, 0)
-
-	const iframePages = pages.filter((page) => page.label.includes('iframe'))
-
-	const iframeLandingPages = pages.filter(
-		(page) => page.label.includes('iframe') && page.label.includes('index')
-	)
-
-	const totalIframe = iframePages.reduce(
-		(acc, cur) => acc + cur.entry_nb_visits,
-		0
-	)
-
-	const totalExitIframe = iframeLandingPages.reduce(
-		(acc, cur) => acc + cur.exit_nb_visits,
-		0
-	)
-	const totalActiveIframe = totalIframe - totalExitIframe
-
-	const landingPage = pages.find((obj) => obj.label === '/index')
-
-	const exitLandingPage = landingPage.exit_nb_visits
-
-	const approximatedTotalIframes = exitLandingPage + totalIframe
-
-	const iframes = (approximatedTotalIframes / totalPages) * 100
-
-	const activeIframes = (totalActiveIframe / approximatedTotalIframes) * 100
-
-	return [iframes, activeIframes]
 }

--- a/source/components/stats/content/Evolution.js
+++ b/source/components/stats/content/Evolution.js
@@ -7,8 +7,7 @@ const Wrapper = styled(Tile.Content)`
 	width: 40%;
 	text-align: center;
 	padding-top: 2rem;
-	margin-bottom: 2rem;
-
+	margin: 0 0.5rem 2rem 0.5rem;
 	@media screen and (max-width: ${1200}px) {
 		width: 100%;
 		padding-top: 0rem;

--- a/source/components/stats/content/IframeFigures.js
+++ b/source/components/stats/content/IframeFigures.js
@@ -1,0 +1,222 @@
+import styled from 'styled-components'
+
+import Table from './sources/Table'
+
+import Tile from '../utils/Tile'
+
+const FigureWrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	padding-top: 0rem;
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+`
+
+const TileWrapper = styled(Tile.Tile)`
+	width: 100%;
+	@media screen and (max-width: ${1200}px) {
+		width: 50%;
+	}
+`
+
+const Number = styled.span`
+	display: block;
+	font-size: 5rem;
+	font-weight: 800;
+	line-height: 1;
+	text-align: center;
+	color: var(--color);
+	transition: color 500ms ease-out;
+	display: inline-flex;
+	align-items: flex-end;
+	justify-content: center;
+`
+const Small = styled(Number)`
+	font-size: 3.5rem;
+`
+const Label = styled.span`
+	text-align: center;
+	font-size: 1.25rem;
+	font-weight: 700;
+`
+
+const Wrapper = styled.table`
+	table-layout: fixed;
+	width: 100%;
+	margin-bottom: 0.5rem;
+	background-color: #fff;
+	border-bottom: 2px solid #f0f0f0;
+	border-collapse: collapse;
+	overflow: hidden;
+
+	tr:nth-child(2n + 1) {
+		background-color: #f9f8f6;
+	}
+
+	th {
+		padding: 0.75rem 0 0.75rem 0.75rem;
+		font-size: 0.875rem;
+		text-align: left;
+		border-bottom: 2px solid #1e1e1e;
+	}
+	td {
+		font-size: 0.8125rem;
+		width: 60%;
+		padding: 0.5rem;
+	}
+	td + td,
+	th + th {
+		width: 20%;
+		font-weight: 700;
+		text-align: right;
+	}
+`
+const Text = styled.p`
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 300;
+	text-align: right;
+`
+const Toggle = styled.button`
+	display: inline;
+	margin: 0;
+	padding: 0;
+	font-size: 0.65rem;
+	color: var(--color);
+	background: none;
+	border: none;
+	cursor: pointer;
+`
+export default function IframeFigures(props) {
+	const [iframes, activeIframes] = props.pages && getIframeRate(props.pages)
+	const [iframePages, totalIframe] =
+		props.pages && getIdentifiedIframes(props.pages)
+
+	return (
+		<div>
+			<FigureWrapper>
+				<TileWrapper>
+					<Tile.Content>
+						<Number>
+							{' '}
+							{Math.round(iframes).toLocaleString('fr-FR')}
+							<Small>&nbsp;%</Small>
+						</Number>
+						<Label>des vistes affichées en iframe</Label>
+					</Tile.Content>
+				</TileWrapper>
+				<TileWrapper>
+					<Tile.Content>
+						<Number>
+							{' '}
+							{Math.round(activeIframes).toLocaleString('fr-FR') || '-'}
+							<Small>&nbsp;%</Small>
+						</Number>
+						<Label>des visites en iframe sont actives</Label>
+					</Tile.Content>
+				</TileWrapper>
+			</FigureWrapper>
+			<Tile.Tile>
+				<Tile.Content>
+					<Wrapper>
+						<tbody>
+							<tr>
+								<th>Intégrateurs identifiés</th>
+								<th>Visites</th>
+								<th>%</th>
+							</tr>
+							{iframePages &&
+								iframePages.map(
+									(line, index) =>
+										index < 5 && (
+											<tr key={line.label + line.entry_nb_visits}>
+												<td>{line.label}</td>
+												<td>
+													{line.entry_nb_visits
+														.toString()
+														.replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}
+												</td>
+												<td>
+													{totalIframe &&
+														Math.round(
+															(line.entry_nb_visits / totalIframe) * 10000
+														) / 100}
+													%
+												</td>
+											</tr>
+										)
+								)}
+						</tbody>
+					</Wrapper>
+					<Text>Données valables pour les 30 derniers jours</Text>
+				</Tile.Content>
+			</Tile.Tile>
+		</div>
+	)
+}
+
+// for iframe rate we consider as iframe url pages which include 'iframe' and inactive landing pages
+const getIframeRate = (pages) => {
+	const totalPages = pages.reduce((acc, cur) => acc + cur.entry_nb_visits, 0)
+
+	const iframePages = pages.filter((page) => page.label.includes('iframe'))
+
+	const totalIframe = iframePages.reduce(
+		(acc, cur) => acc + cur.entry_nb_visits,
+		0
+	)
+
+	const totalExitIframe = iframePages.reduce(
+		(acc, cur) => acc + cur.exit_nb_visits,
+		0
+	)
+	const totalActiveIframe = totalIframe - totalExitIframe
+
+	const landingPage = pages.find((obj) => obj.label === '/index')
+
+	const exitLandingPage = landingPage.exit_nb_visits * 0.6 // 60% of exit are considered as iframes (arbitrary value)
+
+	const approximatedTotalIframes = exitLandingPage + totalIframe
+
+	const iframes = (approximatedTotalIframes / totalPages) * 100
+
+	const activeIframes = (totalActiveIframe / approximatedTotalIframes) * 100
+
+	return [iframes, activeIframes]
+}
+
+const getIdentifiedIframes = (pages) => {
+	const iframePages = pages
+		.filter((page) => page.label.includes('iframe'))
+		.map((page) => {
+			if (!page.url) {
+				return [...page.subtable]
+			} else {
+				page.label = page.label.split('/')[3]
+				return page
+			}
+		})
+		.flat()
+
+	const combined = iframePages.reduce((a, obj) => {
+		if (!a[obj.label]) {
+			a[obj.label] = obj
+			return a
+		} else {
+			Object.entries(obj).map(
+				([key, value]) =>
+					key !== 'label' &&
+					(a[obj.label][key] = (a[obj.label][key] || 0) + value)
+			)
+			return a
+		}
+	}, {})
+
+	const totalIframe = Object.values(combined).reduce(
+		(acc, cur) => acc + cur.entry_nb_visits,
+		0
+	)
+
+	return [iframePages, totalIframe]
+}

--- a/source/components/stats/content/IframeFigures.js
+++ b/source/components/stats/content/IframeFigures.js
@@ -177,15 +177,15 @@ const getIframeRate = (pages, activePages) => {
 		0
 	)
 
-	const landingPage = pages.find((obj) => obj.label === '/index')
+	// const landingPage = pages.find((obj) => obj.label === '/index')
 
-	const exitLandingPage = landingPage.exit_nb_visits * 0.6 // 60% of exit are considered as iframes (arbitrary value)
+	// const exitLandingPage = landingPage.exit_nb_visits * 0.6 // 60% of exit are considered as iframes (arbitrary value)
 
-	const approximatedTotalIframes = exitLandingPage + totalIframe
+	// const approximatedTotalIframes = exitLandingPage + totalIframe
 
-	const iframes = (approximatedTotalIframes / totalPages) * 100
+	const iframes = (totalIframe / totalPages) * 100
 
-	const activeIframes = (totalActiveIframe / approximatedTotalIframes) * 100
+	const activeIframes = (totalActiveIframe / totalIframe) * 100
 
 	return [iframes, activeIframes]
 }

--- a/source/components/stats/content/IframeFigures.js
+++ b/source/components/stats/content/IframeFigures.js
@@ -78,16 +78,7 @@ const Text = styled.p`
 	font-weight: 300;
 	text-align: right;
 `
-const Toggle = styled.button`
-	display: inline;
-	margin: 0;
-	padding: 0;
-	font-size: 0.65rem;
-	color: var(--color);
-	background: none;
-	border: none;
-	cursor: pointer;
-`
+
 export default function IframeFigures(props) {
 	const [iframes, activeIframes] =
 		props.pages && getIframeRate(props.pages, props.activePages)

--- a/source/components/stats/content/IframeFigures.js
+++ b/source/components/stats/content/IframeFigures.js
@@ -89,7 +89,8 @@ const Toggle = styled.button`
 	cursor: pointer;
 `
 export default function IframeFigures(props) {
-	const [iframes, activeIframes] = props.pages && getIframeRate(props.pages)
+	const [iframes, activeIframes] =
+		props.pages && getIframeRate(props.pages, props.activePages)
 	const [iframePages, totalIframe] =
 		props.pages && getIdentifiedIframes(props.pages)
 
@@ -157,7 +158,7 @@ export default function IframeFigures(props) {
 }
 
 // for iframe rate we consider as iframe url pages which include 'iframe' and inactive landing pages
-const getIframeRate = (pages) => {
+const getIframeRate = (pages, activePages) => {
 	const totalPages = pages.reduce((acc, cur) => acc + cur.entry_nb_visits, 0)
 
 	const iframePages = pages.filter((page) => page.label.includes('iframe'))
@@ -167,11 +168,14 @@ const getIframeRate = (pages) => {
 		0
 	)
 
-	const totalExitIframe = iframePages.reduce(
-		(acc, cur) => acc + cur.exit_nb_visits,
+	const activeIframePages = activePages.filter((page) =>
+		page.label.includes('iframe')
+	)
+
+	const totalActiveIframe = activeIframePages.reduce(
+		(acc, cur) => acc + cur.entry_nb_visits,
 		0
 	)
-	const totalActiveIframe = totalIframe - totalExitIframe
 
 	const landingPage = pages.find((obj) => obj.label === '/index')
 

--- a/source/components/stats/content/KmFigures.js
+++ b/source/components/stats/content/KmFigures.js
@@ -3,12 +3,19 @@ import styled from 'styled-components'
 
 import Tile from '../utils/Tile'
 
-const StyledTile = styled(Tile.Wrapper)`
-	> div {
+const FigureWrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	padding-top: 0rem;
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+`
+
+const TileWrapper = styled(Tile.Tile)`
+	width: 100%;
+	@media screen and (max-width: ${1200}px) {
 		width: 50%;
-		/* @media screen and (max-width: ${1200}px) {
-			width: 100%;
-		} */
 	}
 `
 
@@ -30,19 +37,19 @@ export default function KmFigures(props) {
 	const userPercent = (props.kmhelp / props.simulationsfromhelp) * 100
 	const ridesavg = props.ridesnumber / props.kmhelp
 	return (
-		<StyledTile>
-			<Tile.Tile>
+		<FigureWrapper>
+			<TileWrapper>
 				<Tile.Content>
 					<Number> {Math.round(userPercent).toLocaleString('fr-FR')}%</Number>
 					<Label>ont utilisé l'aide à la saisie des km</Label>
 				</Tile.Content>
-			</Tile.Tile>
-			<Tile.Tile>
+			</TileWrapper>
+			<TileWrapper>
 				<Tile.Content>
 					<Number>{Math.round(ridesavg).toLocaleString('fr-FR')}</Number>
 					<Label>trajets saisis en moyenne</Label>
 				</Tile.Content>
-			</Tile.Tile>
-		</StyledTile>
+			</TileWrapper>
+		</FigureWrapper>
 	)
 }

--- a/source/components/stats/content/ScoreFromURL.js
+++ b/source/components/stats/content/ScoreFromURL.js
@@ -1,0 +1,32 @@
+import { rehydrateDetails, sumFromDetails } from '../../../sites/publicodes/fin'
+
+export default function Evolution(props) {
+	const score = props.pages && getScore(props.pages)
+	console.log(score.slice(1))
+	const meanScore = weightedAverage(score.slice(1))
+	console.log(meanScore)
+	return
+}
+
+const getScore = (pages) => {
+	const endPages = pages.filter((page) => page.label.includes('fin'))
+	return endPages.map((obj) => {
+		const regex = /[tasdln](\d*\.?[\d*$])+/g
+		const encodedDetails = obj.label.match(regex).join()
+		const rehydratedDetails = rehydrateDetails(encodedDetails)
+		const score = sumFromDetails(rehydratedDetails)
+		return [score, obj.nb_visits]
+	})
+}
+
+const weightedAverage = (score) => {
+	const [sum, weightSum] = score.reduce(
+		(acc, [value, weight]) => {
+			acc[0] = acc[0] + value * weight
+			acc[1] = acc[1] + weight
+			return acc
+		},
+		[0, 0]
+	)
+	return sum / weightSum
+}

--- a/source/components/stats/content/ScoreFromURL.js
+++ b/source/components/stats/content/ScoreFromURL.js
@@ -26,7 +26,7 @@ const Number = styled.span`
 	transition: color 500ms ease-out;
 	> small {
 		color: var(--lightColor);
-		font-size: 70%;
+		font-size: 60%;
 	}
 `
 const Text = styled.p`
@@ -48,13 +48,14 @@ export default function ScoreFromURL(props) {
 		.map((elt) => [Array(elt[1]).fill(elt[0])])
 		.flat()
 		.flat()
-
+	const totalVisits = flatScoreArray.length
 	return (
 		<Wrapper>
 			<Tile.Tile>
 				<TopBlock>
 					<Number>
-						{roundedMeanScore} tonnes <small>de CO₂e en moyenne</small>
+						{roundedMeanScore} tonnes{' '}
+						<small>de CO₂e en moyenne ({totalVisits} simulations)</small>
 					</Number>
 					<TotalChart flatScoreArray={flatScoreArray} />
 					<Text>Données valables pour les 30 derniers jours</Text>

--- a/source/components/stats/content/ScoreFromURL.js
+++ b/source/components/stats/content/ScoreFromURL.js
@@ -1,14 +1,70 @@
 import { rehydrateDetails, sumFromDetails } from '../../../sites/publicodes/fin'
+import styled from 'styled-components'
+import Tile from '../utils/Tile'
+import { formatValue } from 'publicodes'
+import TotalChart from './TotalChart'
 
-export default function Evolution(props) {
-	const score = props.pages && getScore(props.pages)
-	console.log(score.slice(1))
-	const meanScore = weightedAverage(score.slice(1))
-	console.log(meanScore)
-	return
+const Wrapper = styled.div`
+	width: 100%;
+	text-align: center;
+	padding-top: 0rem;
+`
+
+const TopBlock = styled(Tile.Content)`
+	margin-bottom: 2rem;
+	margin-top: 1rem;
+	width: 100%;
+	font-size: 150%;
+`
+const Number = styled.span`
+	display: block;
+	margin-bottom: 2rem;
+	font-size: 2.5rem;
+	font-weight: 800;
+	line-height: 1;
+	color: var(--color);
+	transition: color 500ms ease-out;
+	> small {
+		color: var(--lightColor);
+		font-size: 70%;
+	}
+`
+const Text = styled.p`
+	margin-top: 1rem;
+	margin-bottom: -1rem;
+	font-size: 0.75rem;
+	font-weight: 300;
+	text-align: right;
+`
+
+export default function ScoreFromURL(props) {
+	const scores = props.pages && getScores(props.pages)
+	// we exclude high number of visits on same urls (corresponds to average test score ?)
+	// pb : if a user goes to end page, come back to test, change test score, come back to end page, 2 score values are taken into account instead of one.
+	const filteredScores = scores.slice(scores.findIndex((elt) => elt[1] < 50))
+	const meanScore = weightedAverage(filteredScores)
+	const roundedMeanScore = formatValue(meanScore / 1000)
+	const flatScoreArray = filteredScores
+		.map((elt) => [Array(elt[1]).fill(elt[0])])
+		.flat()
+		.flat()
+
+	return (
+		<Wrapper>
+			<Tile.Tile>
+				<TopBlock>
+					<Number>
+						{roundedMeanScore} tonnes <small>de CO₂e en moyenne</small>
+					</Number>
+					<TotalChart flatScoreArray={flatScoreArray} />
+					<Text>Données valables pour les 30 derniers jours</Text>
+				</TopBlock>
+			</Tile.Tile>
+		</Wrapper>
+	)
 }
 
-const getScore = (pages) => {
+const getScores = (pages) => {
 	const endPages = pages.filter((page) => page.label.includes('fin'))
 	return endPages.map((obj) => {
 		const regex = /[tasdln](\d*\.?[\d*$])+/g

--- a/source/components/stats/content/TotalChart.js
+++ b/source/components/stats/content/TotalChart.js
@@ -1,0 +1,51 @@
+import emoji from 'react-easy-emoji'
+import { humanWeight } from '../../../sites/publicodes/HumanWeight'
+import { formatValue } from 'publicodes'
+
+export default function TotalChart(props) {
+	const maxScore = Math.max(...props.flatScoreArray),
+		minValue = 2000, // 2 tonnes, the ultimate objective
+		max = humanWeight(maxScore, true).join(' '),
+		min = humanWeight(minValue, true).join(' ')
+	return (
+		<div>
+			<ul
+				title="Empreinte totale"
+				css={`
+					width: 100%;
+					position: relative;
+					margin: 0 auto;
+					border: 2px solid black;
+					height: 2rem;
+					list-style-type: none;
+					li {
+						position: absolute;
+					}
+				`}
+			>
+				{props.flatScoreArray.map((elt, index) => (
+					<li
+						key={index}
+						css={`
+							height: 100%;
+							width: 10px;
+							margin-left: -10px;
+							left: ${((elt - minValue) / (maxScore - minValue)) * 100}%;
+							background: var(--color);
+							opacity: 0.03;
+						`}
+						title={`${formatValue(elt)} t`}
+						aria-label={`${formatValue(elt)} t`}
+					></li>
+				))}
+			</ul>
+			<div css="display: flex; justify-content: space-between; width: 100%">
+				<small key="legendLeft">
+					{emoji('🎯 ')}
+					{min}
+				</small>
+				<small key="legendRight">{max}</small>
+			</div>
+		</div>
+	)
+}

--- a/source/components/stats/content/chart/CustomTooltip.js
+++ b/source/components/stats/content/chart/CustomTooltip.js
@@ -54,7 +54,7 @@ export default function CustomTooltip(props) {
 			<Number>
 				{props.payload[0].value
 					.toString()
-					.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}{' '}
+					.replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}{' '}
 			</Number>
 			{props.naming || 'visites'}
 		</Wrapper>

--- a/source/components/stats/content/histogram/CustomTooltip.js
+++ b/source/components/stats/content/histogram/CustomTooltip.js
@@ -32,7 +32,7 @@ export default function CustomTooltip(props) {
 			<Number>
 				{props.payload[0].value
 					.toString()
-					.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}{' '}
+					.replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}{' '}
 			</Number>
 			{props.naming || 'visites'}
 		</Wrapper>

--- a/source/components/stats/content/sources/Table.js
+++ b/source/components/stats/content/sources/Table.js
@@ -83,7 +83,7 @@ export default function Table(props) {
 											<td>
 												{line.nb_visits
 													.toString()
-													.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}
+													.replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0')}
 											</td>
 											<td>
 												{props.total &&

--- a/source/components/stats/matomo.js
+++ b/source/components/stats/matomo.js
@@ -124,17 +124,24 @@ export const useReference = () =>
 		(res) => res.data
 	)
 
-export const usePages = () =>
+export const useEntryPages = () =>
 	useX(
-		'pages',
+		'entryPages',
 		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getEntryPageUrls&expanded=1&filter_limit=1000`,
 		(res) => res.data
 	)
 
-export const useActivePages = () =>
+export const useActiveEntryPages = () =>
 	useX(
-		'activePages',
+		'activeEntryPages',
 		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getEntryPageUrls&filter_limit=1000&segment=eventAction%3D%3DClic%252520CTA%252520accueil`,
+		(res) => res.data
+	)
+
+export const usePages = () =>
+	useX(
+		'pages',
+		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getPageUrls&filter_limit=-1`,
 		(res) => res.data
 	)
 

--- a/source/components/stats/matomo.js
+++ b/source/components/stats/matomo.js
@@ -127,7 +127,7 @@ export const useReference = () =>
 export const usePages = () =>
 	useX(
 		'pages',
-		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getEntryPageUrls&filter_limit=1000`,
+		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getEntryPageUrls&expanded=1&filter_limit=1000`,
 		(res) => res.data
 	)
 

--- a/source/components/stats/matomo.js
+++ b/source/components/stats/matomo.js
@@ -131,6 +131,13 @@ export const usePages = () =>
 		(res) => res.data
 	)
 
+export const useActivePages = () =>
+	useX(
+		'activePages',
+		`module=API&date=last30&period=range&format=json&idSite=${idSite}&method=Actions.getEntryPageUrls&filter_limit=1000&segment=eventAction%3D%3DClic%252520CTA%252520accueil`,
+		(res) => res.data
+	)
+
 export const useAllTime = () =>
 	useX(
 		'allTime',

--- a/source/components/stats/utils/Section.js
+++ b/source/components/stats/utils/Section.js
@@ -23,7 +23,7 @@ Section.Title = styled.h2`
 Section.Intro = styled.details`
 	font-size: 1rem;
 	line-height: 1.3rem;
-	margin: 1rem 0 0.5rem 0;
+	margin: 1rem 0 1rem 0;
 	> summary {
 		font-size: 1.3rem;
 		margin-bottom: 0.5rem;

--- a/source/components/stats/utils/Section.js
+++ b/source/components/stats/utils/Section.js
@@ -21,9 +21,11 @@ Section.Title = styled.h2`
 `
 
 Section.Intro = styled.details`
-	font-size: 1rem;
-	line-height: 1.3rem;
 	margin: 1rem 0 1rem 0;
+	p {
+		font-size: 1rem;
+		line-height: 1.3rem;
+	}
 	> summary {
 		font-size: 1.3rem;
 		margin-bottom: 0.5rem;

--- a/source/components/stats/utils/Tile.js
+++ b/source/components/stats/utils/Tile.js
@@ -63,7 +63,6 @@ export default function Tile(props) {
 Tile.Wrapper = styled.div`
 	display: flex;
 	flex-wrap: wrap;
-	margin: 0 -0.5rem;
 `
 Tile.Tile = TileWrapper
 Tile.Content = Content

--- a/source/components/utils/IframeOptionsProvider.tsx
+++ b/source/components/utils/IframeOptionsProvider.tsx
@@ -20,11 +20,10 @@ export default function IframeOptionsProvider({ children, tracker }) {
 
 	tracker &&
 		tracker.push([
-			'setCustomVariable',
-			'1',
-			'visite depuis iframe ?',
+			'trackEvent',
+			'iframe',
+			'visites via iframe',
 			!isIframe ? 'non' : integratorUrl,
-			'visit',
 		])
 
 	const iframeIntegratorOptions = Object.fromEntries(

--- a/source/components/utils/IframeOptionsProvider.tsx
+++ b/source/components/utils/IframeOptionsProvider.tsx
@@ -14,7 +14,7 @@ export default function IframeOptionsProvider({ children, tracker }) {
 		urlParams.set('integratorUrl', document.referrer)
 	}
 
-	const isIframe = urlParams.get('iframe') !== null
+	const isIframe = urlParams.get('iframe') != null
 
 	const integratorUrl = isIframe && urlParams.get('integratorUrl')
 

--- a/source/components/utils/IframeOptionsProvider.tsx
+++ b/source/components/utils/IframeOptionsProvider.tsx
@@ -7,8 +7,16 @@ const nullDecode = (string) =>
 
 export default function IframeOptionsProvider({ children, tracker }) {
 	const urlParams = new URLSearchParams(window.location.search)
-	const isIframe = urlParams.get('iframe') != null,
-		integratorUrl = isIframe && urlParams.get('integratorUrl')
+	const isIframeWithScript = urlParams.get('iframe') != null
+
+	if (!isIframeWithScript && window.self !== window.top) {
+		urlParams.set('iframe', '')
+		urlParams.set('integratorUrl', document.referrer)
+	}
+
+	const isIframe = urlParams.get('iframe') !== null
+
+	const integratorUrl = isIframe && urlParams.get('integratorUrl')
 
 	tracker &&
 		tracker.push([

--- a/source/sites/publicodes/fin/index.tsx
+++ b/source/sites/publicodes/fin/index.tsx
@@ -20,7 +20,7 @@ import Petrogaz from './Petrogaz'
 const { encodeRuleName } = utils
 
 // details=a2.6t2.1s1.3l1.0b0.8f0.2n0.1
-const rehydrateDetails = (encodedDetails) =>
+export const rehydrateDetails = (encodedDetails) =>
 	encodedDetails &&
 	encodedDetails
 		.match(/[a-z][0-9]+\.[0-9][0-9]/g)
@@ -31,7 +31,7 @@ const rehydrateDetails = (encodedDetails) =>
 			category === 'b' ? ['d', ...rest] : [category, ...rest]
 		)
 
-const sumFromDetails = (details) =>
+export const sumFromDetails = (details) =>
 	details.reduce((memo, [name, value]) => memo + value, 0)
 
 export default ({}) => {
@@ -40,6 +40,7 @@ export default ({}) => {
 	const slideName = searchParams.get('diapo') || 'bilan'
 
 	const rehydratedDetails = rehydrateDetails(encodedDetails)
+	console.log(rehydratedDetails)
 
 	const score = sumFromDetails(rehydratedDetails)
 	const headlessMode =

--- a/source/sites/publicodes/fin/index.tsx
+++ b/source/sites/publicodes/fin/index.tsx
@@ -40,7 +40,6 @@ export default ({}) => {
 	const slideName = searchParams.get('diapo') || 'bilan'
 
 	const rehydratedDetails = rehydrateDetails(encodedDetails)
-	console.log(rehydratedDetails)
 
 	const score = sumFromDetails(rehydratedDetails)
 	const headlessMode =

--- a/source/sites/publicodes/iframe.js
+++ b/source/sites/publicodes/iframe.js
@@ -1,4 +1,7 @@
 import { iframeResize } from 'iframe-resizer'
+import { TrackerContext } from 'Components/utils/withTracker'
+
+const tracker = useContext(TrackerContext)
 
 const script =
 		document.getElementById('ecolab-climat') ||
@@ -41,8 +44,7 @@ iframeResize({}, iframe)
 
 const link = document.createElement('div')
 link.innerHTML = `
-<a href="https://nosgestesclimat.fr" target="_blank">Calculer mon empreinte carbone ⬇️</a>
-
+<a href="https://nosgestesclimat.fr" target="_blank" onClick={() => tracker.push(['trackEvent','iframe','Clic redirection nosgestesclimat.fr', ${integratorUrl},])}>Calculer mon empreinte carbone ⬇️</a>
 `
 link.style.cssText = `
 margin: 1rem auto .6rem;

--- a/source/sites/publicodes/iframe.js
+++ b/source/sites/publicodes/iframe.js
@@ -1,7 +1,4 @@
 import { iframeResize } from 'iframe-resizer'
-import { TrackerContext } from 'Components/utils/withTracker'
-
-const tracker = useContext(TrackerContext)
 
 const script =
 		document.getElementById('ecolab-climat') ||
@@ -44,7 +41,8 @@ iframeResize({}, iframe)
 
 const link = document.createElement('div')
 link.innerHTML = `
-<a href="https://nosgestesclimat.fr" target="_blank" onClick={() => tracker.push(['trackEvent','iframe','Clic redirection nosgestesclimat.fr', ${integratorUrl},])}>Calculer mon empreinte carbone ⬇️</a>
+<a href="https://nosgestesclimat.fr" target="_blank">Calculer mon empreinte carbone ⬇️</a>
+
 `
 link.style.cssText = `
 margin: 1rem auto .6rem;


### PR DESCRIPTION
Démo : https://ameliorations-page-stats--nosgestesclimat.netlify.app/stats

- [x] Affichage du taux d'iframe
- [x] Nouvelle manière de détecter les iframe
- [x] Ajout d'un tracker pour vérifier que le nouveau taux d'iframe est correct
- [x] Ajout d'un tracker sur le bouton "Calculer mon empreinte carbone" des iframes (-> je ne sais pas si ça va fonctionner)
- [x] Analyse des urls de fin -> **Pb: matomo limite à 500 le nombre d'urls de pages captés (https://fr.matomo.org/faq/how-to/faq_54/)**
- [x] Affichage de statistiques sur les urls de fin dans les stats