### PR TITLE
arrondi ⵛ

### DIFF
--- a/source/sites/publicodes/HumanWeight.js
+++ b/source/sites/publicodes/HumanWeight.js
@@ -3,20 +3,19 @@ import { disabledAction, supersededAction } from './ActionVignette'
 
 export const humanWeight = (possiblyNegativeValue, concise = false, noSign) => {
 	const v = Math.abs(possiblyNegativeValue)
-	const [raw, unit] =
+	const [raw, unit, digits] =
 		v === 0
-			? [v, '']
+			? [v, '', 0]
 			: v < 1
-			? [v * 1000, 'g']
+			? [v * 1000, 'g', 0]
 			: v < 1000
-			? [v, 'kg']
-			: [v / 1000, concise ? 't' : v > 2000 ? 'tonnes' : 'tonne']
+			? [v, 'kg', 0]
+			: [v / 1000, concise ? 't' : v > 2000 ? 'tonnes' : 'tonne', 1]
 
 	const signedValue = raw * (possiblyNegativeValue < 0 ? -1 : 1),
 		resultValue = noSign ? raw : signedValue,
 		value = resultValue.toLocaleString('fr-FR', {
-			minimumFractionDigits: 1,
-			maximumFractionDigits: 1,
+			maximumFractionDigits: digits,
 		})
 
 	return [value, unit]


### PR DESCRIPTION
- Meilleure gestion des arrondis sur les valeurs en poids de CO2e

- [ ] voir si ça impact correctement le reste des composants (hors ActionVignette pour lequel cette PR existe)

Avant 

![image](https://user-images.githubusercontent.com/1177762/195046228-4056dabb-7d66-4658-a1d0-29116ee01844.png)


Après 

![image](https://user-images.githubusercontent.com/1177762/195046163-d4aefb57-99f5-4adb-add7-003554c99588.png)

