### PR TITLE
Docs: new section in the /diffuser page

### DIFF
--- a/source/locales/pages/en-us/diffuser.md
+++ b/source/locales/pages/en-us/diffuser.md
@@ -1,68 +1,59 @@
-# Disseminate Our Climate Actions
+# Disseminate Nos Gestes Climat
 
-Nos Gestes Climat is a public service, its code [is
-free](/documentation) and reusable by everyone.
+Nos Gestes Climat is a public service, its code <a href="/documentation">is free</a> and reusable by everyone.
 
-However, you can take advantage of and distribute our simulator in
-several ways without mobilizing development skills.
+However, you can take advantage of and distribute our simulator in several ways without mobilizing development skills.
 
-## You want to integrate the simulator directly on your website
+## You want to share a page in a specific language
 
-Nothing could be easier! Integrate it into a blog post or site simply by
-adding the line below to your web page.
+Since the version <a href="https://nosgestesclimat.fr/nouveautés/glacier-du-géant">Glacier du Géant</a>, the interface of the Nos Gestes Climat website is translated into several languages. You can therefore share a page of the site in a specific language by indicating at the end of the the URL `?lang=en`.
 
-`<script id="nosgestesclimat" src="https://nosgestesclimat.fr/iframe.js"></script>`
+For example, to share the page _/diffuser_ in English :
 
-Join [the many current
-reusers](https://datagir.ademe.fr/apps/nos-gestes-climat/) in this way.
+`https://nosgestesclimat.fr/diffuser?lang=en`
 
-The module will automatically stay up to date with the [latest
-developments](/nouveautés).
+The currently supported languages are French (`fr`) and English (`en`).
 
-To learn more about integration, visit [our
-guide](https://github.com/datagir/nosgestesclimat-site/blob/master/PERSONNALISATION.md).
+> Note that when you change the interface language, the NGC's model remains unchanged. It is only the text of the site that is translated and not the NGC's model itself.
+
+## You want to integrate the simulator directly on your site
+
+Nothing could be easier! Integrate it in a blog post or a website simply by adding the line below to your web page.
+
+<script id="nosgestesclimat" src="https://nosgestesclimat.fr/iframe.js"></script>
+
+Join <a href="https://datagir.ademe.fr/apps/nos-gestes-climat/">the many current reusers</a>.
+
+The module will automatically stay up to date with the <a href="/nouveautés">latest developments</a>.
+
+To learn more about the integration, visit <a href="https://github.com/datagir/nosgestesclimat-site/blob/master/PERSONNALISATION.md">our guide</a>.
 
 ## You host climate conferences
 
-To spice up a conference and make your listeners active on their phones,
-what could be better than letting them do a live simulation?
+To spice up a conference and get your listeners active on their phones, what better way than to let them do a live simulation?
 
-You want to estimate the climate footprint of a group of people, or
-simply integrate the simulator and retrieve the simulation result in the
-user's account?
+You want to estimate the climate footprint of a group of people, or simply integrate the simulator and retrieve the simulation result in the user's account?
 
 The "conference" and "survey" features are now available!
 
-Go to [🏟️ group mode](/groupe) on choose a room name, share the link,
-and launch the simulation match!
+Go to <a href="/groupe">🏟️ group mode</a> on choose a room name, share the link, and launch the simulation game!
 
-## <span role="img" aria-label="" aria-hidden="true">🇬🇧</span> You want the same calculator tailored to your country
+## You want the same calculator tailored to your country
 
-We are looking for native partners to translate and adapt the GHG
-emissions model for the specificities of other countries.
-
-> We are actively looking for foreign partners to decline Our Climate
-> Gestures in other countries.
+We are looking for native partners to translate and adapt the GHG emissions model for the specificities of other countries.
 
 ## You want to customize the tool for your own needs
 
-To learn more about custom integration<span lang="en">(</span>
-configured<span lang="en">iframe</span>, code fork), visit [our
-customization
-guide](https://github.com/datagir/nosgestesclimat-site/blob/master/PERSONNALISATION.md).
+To learn more about custom integration (configured iframe, code fork), visit <a href="https://github.com/datagir/nosgestesclimat-site/blob/master/PERSONNALISATION.md">our customization guide</a>.
 
 ## You just want to help us
 
 Contributions are free. We are looking for :
 
--   people who like to juggle physical units and model calculations by
-    finding the best available data sources
--   developers and designers to improve the site, its design and its
-    features
+-   people who like to juggle physical units and model calculations by finding the best available data sources
+-   developers and designers to improve the site, its design and its features
 
-Everything is on
-[Github](https://github.com/datagir/?q=nosgestesclimat&type=&language=&sort=),
-but feel free to contact us directly.
+Everything is on <a href="https://github.com/datagir/?q=nosgestesclimat&type=&language=&sort=">Github</a>, but feel free to contact us directly.
 
 ## Contact us
 

--- a/source/locales/pages/en-us/diffuser.md
+++ b/source/locales/pages/en-us/diffuser.md
@@ -14,7 +14,7 @@ For example, to share the page _/diffuser_ in English :
 
 The currently supported languages are French (`fr`) and English (`en`).
 
-> Note that when you change the interface language, the NGC's model remains unchanged. It is only the text of the site that is translated and not the NGC's model itself.
+> Note that when you change the interface language, the model of calculation remains unchanged. Only the website's text is translated.
 
 ## You want to integrate the simulator directly on your site
 

--- a/source/locales/pages/fr/diffuser.md
+++ b/source/locales/pages/fr/diffuser.md
@@ -4,6 +4,23 @@ Nos Gestes Climat est un service public, son code [est libre](/documentation) et
 
 Cependant, vous pouvez profiter et diffuser notre simulateur de plusieurs façons sans mobiliser des compétences de développement.
 
+## Vous souhaitez partager une page dans une langue spécifique
+
+Depuis la version [Glacier du Géant](https://nosgestesclimat.fr/nouveautés/glacier-du-géant), l'interface du
+site Nos Gestes Climat est traduite dans plusieurs langues. Vous pouvez donc
+partager une page du site dans une langue spécifique en précisant à la fin de
+l'URL `?lang=en`.
+
+Par exemple, pour partager la page  _/diffuser_ en anglais :
+
+`https://nosgestesclimat.fr/diffuser?lang=en`
+
+Les langues supportées actuellement sont le français (`fr`) et l'anglais (`en`).
+
+> Notez que lorsque vous changez la langue de l'interface, le modèle reste
+> inchangé. C'est simplement le texte du site qui est traduit et non le modèle
+> en lui-même.
+
 ## Vous voulez intégrer le simulateur directement sur votre site
 
 Rien de plus simple ! Intégrez le dans un article de blog ou un site simplement en ajoutant la ligne ci-dessous à votre page web.


### PR DESCRIPTION
Add a new section to the `/diffuser` page:

French version:
![fr-diffuser](https://user-images.githubusercontent.com/44124798/201162494-71f0efa4-a919-4f4c-aa04-b1236a768af5.png)

English version:
![en-diffuser](https://user-images.githubusercontent.com/44124798/201162533-bc03d892-0393-4bdf-8f38-b59090b4e7e8.png)