### PR TITLE
Ajout des tags de langage pour Google & co

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
 			content="<%= htmlWebpackPlugin.options.description %>"
 			data-react-helmet="true"
 		/>
+		 <link rel="alternate" hreflang="en" href="https://nosgestesclimat.fr/?lang=en" />
+		 <link rel="alternate" hreflang="fr" href="https://nosgestesclimat.fr/?lang=fr" />
+		 <link rel="alternate" hreflang="x-default" href="https://nosgestesclimat.fr" />
+
 		<meta property="og:type" content="website" />
 		<meta
 			property="og:title"

--- a/source/components/utils/Meta.tsx
+++ b/source/components/utils/Meta.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet'
+import { useLocation } from 'react-router-dom'
 
 type PropType = {
 	title: string
@@ -9,6 +10,8 @@ type PropType = {
 	more?: ReactNode | null
 }
 
+const websiteURL = 'https://nosgestesclimat.fr'
+
 export default function Meta({
 	title,
 	description,
@@ -16,6 +19,7 @@ export default function Meta({
 	url,
 	children,
 }: PropType) {
+	const { pathname } = useLocation()
 	return (
 		<Helmet>
 			<title>{title} - Nos Gestes Climat</title>
@@ -28,6 +32,17 @@ export default function Meta({
 			{image && <meta property="og:image" content={image} />}
 			{url && <meta property="og:url" content={url} />}
 			{children}
+			<link
+				rel="alternate"
+				hrefLang="en"
+				href={websiteURL + pathname + '?lang=en'}
+			/>
+			<link
+				rel="alternate"
+				hrefLang="fr"
+				href={websiteURL + pathname + '?lang=fr'}
+			/>
+			<link rel="alternate" hrefLang="x-default" href={websiteURL + pathname} />
 		</Helmet>
 	)
 }


### PR DESCRIPTION
Selon cette documentation https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=fr

Je ne sais pas si on devrait rendre dynamiques ces tags via Meta.tsx, ou
vu que l'on est une SPA, peut-être que ça suffit ainsi ?

C'est de toutes façons mieux ainsi
