### PR TITLE
précision inutile kg

### DIFF
--- a/source/sites/publicodes/HumanWeight.js
+++ b/source/sites/publicodes/HumanWeight.js
@@ -25,8 +25,8 @@ export const humanWeight = (
 	const signedValue = raw * (possiblyNegativeValue < 0 ? -1 : 1),
 		resultValue = noSign ? raw : signedValue,
 		value = resultValue.toLocaleString(abrvLocale, {
-			minimumFractionDigits: 1,
-			maximumFractionDigits: 1,
+			minimumFractionDigits: v < 1000 ? 0 : 1,
+			maximumFractionDigits: v < 1000 ? 0 : 1,
 		})
 
 	return [value, unit]

--- a/source/sites/publicodes/HumanWeight.js
+++ b/source/sites/publicodes/HumanWeight.js
@@ -11,22 +11,22 @@ export const humanWeight = (
 	noSign
 ) => {
 	const v = Math.abs(possiblyNegativeValue)
-	const [raw, unit, _digits] =
+	const [raw, unit, digits] =
 		v === 0
 			? [v, '', 0]
 			: v < 1
-			? [v * 1000, 'g', 0]
+			? [v * 1000, 'g', 1]
 			: v < 1000
-			? [v, 'kg']
-			: [v / 1000, concise ? 't' : v > 2000 ? t('tonnes') : t('tonne')]
+			? [v, 'kg', 0]
+			: [v / 1000, concise ? 't' : v > 2000 ? t('tonnes') : t('tonne'), 1]
 
 	const abrvLocale = getCurrentLangInfos(i18n).abrvLocale
 
 	const signedValue = raw * (possiblyNegativeValue < 0 ? -1 : 1),
 		resultValue = noSign ? raw : signedValue,
 		value = resultValue.toLocaleString(abrvLocale, {
-			minimumFractionDigits: v < 1000 ? 0 : 1,
-			maximumFractionDigits: v < 1000 ? 0 : 1,
+			minimumFractionDigits: digits,
+			maximumFractionDigits: digits,
 		})
 
 	return [value, unit]


### PR DESCRIPTION
Je pense que l'affichage au dixième de kg de CO2e n'est pas utile dans NGC, je propose d'arrondir au kg près (d'autant que la précision n'est pas cohérente avec la précision en tonnes

<img width="665" alt="image" src="https://user-images.githubusercontent.com/55186402/203562659-7b796c39-03a7-4c9c-a0f2-9fbf9a8c63ab.png">
<img width="672" alt="image" src="https://user-images.githubusercontent.com/55186402/203562727-9f05f51e-771b-408a-96d3-85c7249f6636.png">
