### PR TITLE
Typo "annnées" --> "année"

### DIFF
--- a/source/locales/units.yaml
+++ b/source/locales/units.yaml
@@ -2,7 +2,7 @@ fr:
   € / an: € / an
   an: an
   année: année
-  années: annnées
+  années: années
   ans: ans
   climatiseur: climatiseur
   h / an: h / an


### PR DESCRIPTION
Dans la partie "âge du véhicule", typo identifiée