### PR TITLE
Fix espaces nom sondage

### DIFF
--- a/source/sites/publicodes/conference/NamingBlock.tsx
+++ b/source/sites/publicodes/conference/NamingBlock.tsx
@@ -61,8 +61,8 @@ export default ({ newRoom, setNewRoom }) => {
 					<Trans
 						i18nKey={`publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres`}
 					>
-						💡 Votre nom de salle ne peut que contenir des lettres, des
-						chifffres et des tirets
+						💡 Votre nom de salle ne peut que contenir des lettres, des chiffres
+						et des tirets
 					</Trans>
 				</p>
 			)}

--- a/source/sites/publicodes/conference/NamingBlock.tsx
+++ b/source/sites/publicodes/conference/NamingBlock.tsx
@@ -23,7 +23,7 @@ export default ({ newRoom, setNewRoom }) => {
 								e.target.value.replace(specialCharaters, '')
 							} else {
 								setShowInvalidMessage(false)
-								setNewRoom(e.target.value)
+								setNewRoom(e.target.value.trim())
 							}
 						}}
 						css="width: 80% !important"


### PR DESCRIPTION
Pour corriger #814 

Dans le fix proposé, on n'accepte plus aucun espace dans le nom du sondage, est ce qu'on est ok avec ça ou on aimerait que ce soit seulement le dernier espace du nom qui soit non pris en compte ?

Je me dis que ça éviterait peut être les erreurs récurrentes sur le sondage ?

Reste le problème de personne qui pourraient créer un sondage via l'url...