### PR TITLE
Amélioration de la visibilité du nombre participants sur les modes groupe

### DIFF
--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -936,6 +936,20 @@ entries:
     Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
   publicodes.conference.Survey.libreOffice: To open it with <2>LibreOffice</2>, it is automatic.
   publicodes.conference.Survey.libreOffice.lock: Pour l'ouvrir avec <2>LibreOffice</2>, c'est automatique.
+  publicodes.conference.Survey.notCreatedWarning1: Please note that there is no
+    such poll at this address. To launch a poll, the organizer must first create
+    it on the <2>group mode</2> page.
+  publicodes.conference.Survey.notCreatedWarning1.lock: Attention, il n'existe
+    aucun ce sondage à cette adresse. Pour lancer un sondage, l'organisateur
+    doit d'abord le créer sur la page du <2>mode groupe</2>.
+  publicodes.conference.Survey.notCreatedWarning2:
+    Perhaps you made a typo in the
+    survey address? Remember to use the correct capitalization, copy and paste
+    the exact address or use the QR code.
+  publicodes.conference.Survey.notCreatedWarning2.lock: Peut-être avez-vous fait
+    une faute de frappe dans l'adresse du sondage ? Pensez notamment à bien
+    respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le
+    QR code.
   publicodes.conference.Survey.resultat:
     The results on the view page only include
     participants who completed <1>at least 10% of the test</1>. The CSV, on the
@@ -1001,6 +1015,11 @@ entries:
   simulation-end.title.lock: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations completed since the launch
+  site.publicodes.conferences.Stats.explication0: Each vertical bar ☝️ is the
+    total score of a participant,<1></1>each disc 👇️ a score on a category.
+  site.publicodes.conferences.Stats.explication0.lock: Chaque barre verticale ☝️
+    est le score total d'un participant,<1></1>chaque disque 👇️ un score sur
+    une catégorie.
   site.publicodes.conferences.Stats.explication1: '<0>In yellow</0>: my score of {{spotlightValue}} t.'
   site.publicodes.conferences.Stats.explication1.lock: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
   sites.publicodes.Landing.description: In 10 minutes, get an estimate of your carbon footprint.

--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -15,6 +15,7 @@ entries:
   'Actions écartées :': 'Discarded actions:'
   Afficher l'explication du score: Show score explanation
   Afficher ma simulation: Show my simulation
+  Afficher mon score: Show my score
   Agir: Act
   Aide à la saisie: Input help
   Ajouter: Add
@@ -33,6 +34,9 @@ entries:
   Ce guide n'existe pas encore: This guide does not exist yet
   "Cette contribution sera publique : n'y mettez pas d'informations sensibles": 'This contribution will be public: do not put sensitive information in it'
   Cette fiche détaillée n'existe pas encore: This detailed sheet does not exist yet
+  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.:
+    This page allows you to navigate the Nos Gestes Climat paths as if you were
+    one of the typical profiles we have listed.
   Chargement: Loading
   Chargement du modèle de calcul...: Loading the calculation model...
   Chargement...: Loading...
@@ -161,8 +165,10 @@ entries:
   Nbre de personnes: Number of people
   Nom de la salle: Name of the room
   Nombre de personnes: Number of people
+  Nombre de tests terminés: Number of completed tests
   Nombre de visites pour les: Number of visits for
   Nombre de visites pour les 60 derniers jours: Number of visits for the last 60 days
+  Nombre total de participants: Total number of participants
   Non: No
   Non applicable: Not applicable
   Nos Gestes Climat Conférence: Our Climate Action Conference
@@ -171,6 +177,7 @@ entries:
   Notre serveur semble indisponible: Our server seems to be unavailable
   Nous avons détecté que vous faites cette simulation depuis: We have detected that you are doing this simulation from
   Nouveautés: News
+  'Nouveautés - ': 'New products - '
   'Nouveautés - version ': "What's new - version "
   On la mesure comment ?: How is it measured?
   On vous propose une sélection graduelle de gestes.: We propose a gradual selection of gestures.
@@ -590,8 +597,9 @@ entries:
   pages.News.determinant: of
   pages.News.determinant.lock: of
   pages.News.premierParagraphe: We are continuously improving the site based on
-    your feedback. Discover here the
-  pages.News.premierParagraphe.lock: Nous améliorons le site en continu à partir de vos retours. Découvrez ici les
+    your feedback. Discover here the latest news.
+  pages.News.premierParagraphe.lock: Nous améliorons le site en continu à partir
+    de vos retours. Découvrez ici les dernières nouveautés.
   participant: participant
   pleins: full tanks
   pleins de pétrole: full tanks of oil
@@ -993,8 +1001,8 @@ entries:
   simulation-end.title.lock: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations completed since the launch
-  site.publicodes.conferences.Stats.explication1: '<0>In yellow</0>: my simulation at {{spotlightValue}} t.'
-  site.publicodes.conferences.Stats.explication1.lock: '<0>En jaune</0> : ma simulation à {{spotlightValue}} t.'
+  site.publicodes.conferences.Stats.explication1: '<0>In yellow</0>: my score of {{spotlightValue}} t.'
+  site.publicodes.conferences.Stats.explication1.lock: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
   sites.publicodes.Landing.description: In 10 minutes, get an estimate of your carbon footprint.
   sites.publicodes.Landing.description.lock:
     En 10 minutes, obtenez une estimation

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -626,6 +626,14 @@ entries:
     un tableur vide, puis Données > À partir d''un fichier texte / CSV.
     Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
   publicodes.conference.Survey.libreOffice: Pour l'ouvrir avec <2>LibreOffice</2>, c'est automatique.
+  publicodes.conference.Survey.notCreatedWarning1:
+    Attention, il n'existe aucun ce
+    sondage à cette adresse. Pour lancer un sondage, l'organisateur doit d'abord
+    le créer sur la page du <2>mode groupe</2>.
+  publicodes.conference.Survey.notCreatedWarning2: Peut-être avez-vous fait une
+    faute de frappe dans l'adresse du sondage ? Pensez notamment à bien
+    respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le
+    QR code.
   publicodes.conference.Survey.resultat:
     Les résultats de la page de visualisation
     ne prennent en compte que les participants ayant rempli <1>au moins 10% du
@@ -665,6 +673,10 @@ entries:
   simulation-end.title: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations terminées depuis le lancement
+  site.publicodes.conferences.Stats.explication0:
+    Chaque barre verticale ☝️ est le
+    score total d'un participant,<1></1>chaque disque 👇️ un score sur une
+    catégorie.
   site.publicodes.conferences.Stats.explication1: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
   sites.publicodes.Landing.description: En 10 minutes, obtenez une estimation de
     votre empreinte carbone de consommation.

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -603,8 +603,8 @@ entries:
   publicodes.conference.Instructions.intro: <0>Le test d'empreinte climat est
     individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun
     sera derrière son écran, mais visualisera en temps réel les résultats des
-    autres.</0><1>C'est l'occasion de se confronter aux autres et de réfléchir
-    ensemble aux enjeux de notre propre impact.</1>
+    autres.</0><1>C'est l'occasion de réfléchir ensemble aux enjeux de notre
+    propre impact en comparant nos modes de vie.</1>
   publicodes.conference.Instructions.liensSimulationConference:
     Au moment convenu, ouvrez ce lien tous en même temps et faites chacun de
     votre côté votre simulation.

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -161,8 +161,10 @@ entries:
   Nbre de personnes: Nbre de personnes
   Nom de la salle: Nom de la salle
   Nombre de personnes: Nombre de personnes
+  Nombre de tests terminés: Nombre de tests terminés
   Nombre de visites pour les: Nombre de visites pour les
   Nombre de visites pour les 60 derniers jours: Nombre de visites pour les 60 derniers jours
+  Nombre total de participants: Nombre total de participants
   Non: Non
   Non applicable: Non applicable
   Nos Gestes Climat Conférence: Nos Gestes Climat Conférence

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -13,6 +13,7 @@ entries:
   'Actions écartées :': 'Actions écartées :'
   Afficher l'explication du score: Afficher l'explication du score
   Afficher ma simulation: Afficher ma simulation
+  Afficher mon score: Afficher mon score
   Agir: Agir
   Aide à la saisie: Aide à la saisie
   Ajouter: Ajouter
@@ -31,6 +32,9 @@ entries:
   Ce guide n'existe pas encore: Ce guide n'existe pas encore
   "Cette contribution sera publique : n'y mettez pas d'informations sensibles": "Cette contribution sera publique : n'y mettez pas d'informations sensibles"
   Cette fiche détaillée n'existe pas encore: Cette fiche détaillée n'existe pas encore
+  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.:
+    Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si
+    vous étiez l'un des profils types que nous avons listés.
   Chargement: Chargement
   Chargement du modèle de calcul...: Chargement du modèle de calcul...
   Chargement...: Chargement...
@@ -659,7 +663,7 @@ entries:
   simulation-end.title: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations terminées depuis le lancement
-  site.publicodes.conferences.Stats.explication1: '<0>En jaune</0> : ma simulation à {{spotlightValue}} t.'
+  site.publicodes.conferences.Stats.explication1: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
   sites.publicodes.Landing.description: En 10 minutes, obtenez une estimation de
     votre empreinte carbone de consommation.
   sites.publicodes.LandingExplanations.faqLink: |-

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -602,7 +602,7 @@ entries:
     page
   publicodes.conference.Instructions.intro: <0>Le test d'empreinte climat est
     individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun
-    sera derrière son écran, mais visualisera en temps-réel les résultats des
+    sera derrière son écran, mais visualisera en temps réel les résultats des
     autres.</0><1>C'est l'occasion de se confronter aux autres et de réfléchir
     ensemble aux enjeux de notre propre impact.</1>
   publicodes.conference.Instructions.liensSimulationConference:
@@ -626,8 +626,7 @@ entries:
     un tableur vide, puis Données > À partir d''un fichier texte / CSV.
     Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
   publicodes.conference.Survey.libreOffice: Pour l'ouvrir avec <2>LibreOffice</2>, c'est automatique.
-  publicodes.conference.Survey.notCreatedWarning1:
-    Attention, il n'existe aucun ce
+  publicodes.conference.Survey.notCreatedWarning1: Attention, il n'existe aucun
     sondage à cette adresse. Pour lancer un sondage, l'organisateur doit d'abord
     le créer sur la page du <2>mode groupe</2>.
   publicodes.conference.Survey.notCreatedWarning2: Peut-être avez-vous fait une

--- a/source/sites/publicodes/conference/Conference.tsx
+++ b/source/sites/publicodes/conference/Conference.tsx
@@ -12,7 +12,12 @@ import Instructions from './Instructions'
 import Stats from './Stats'
 import { UserBlock } from './UserList'
 import useYjs from './useYjs'
-import { defaultThreshold, getExtremes } from './utils'
+import {
+	defaultProgressMin,
+	defaultThreshold,
+	getElements,
+	getExtremes,
+} from './utils'
 
 export const ConferenceTitle = styled.h2`
 	margin-top: 0.6rem;
@@ -26,6 +31,11 @@ export const ConferenceTitle = styled.h2`
 	align-items: center;
 	font-size: 120%;
 `
+export const conferenceElementsAdapter = (elements) =>
+	Object.entries(elements).map(([username, data]) => ({
+		...data,
+		username,
+	}))
 
 export default () => {
 	const { room } = useParams()
@@ -41,6 +51,15 @@ export default () => {
 	const extremes = getExtremes(elements, threshold)
 
 	const { t } = useTranslation()
+
+	const rawElements = conferenceElementsAdapter(elements)
+	const statsElements = getElements(
+		rawElements,
+		threshold,
+		null,
+		defaultProgressMin
+	)
+	const totalElements = getElements(rawElements, threshold, null, 0)
 
 	return (
 		<div>
@@ -64,10 +83,8 @@ export default () => {
 			</ConferenceTitle>
 			<Stats
 				{...{
-					elements: Object.entries(elements).map(([username, data]) => ({
-						...data,
-						username,
-					})),
+					totalElements,
+					elements: statsElements,
 					users,
 					username,
 					threshold,

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -1,7 +1,6 @@
 import { correctValue, extractCategories } from 'Components/publicodesUtils'
 import { useEngine } from 'Components/utils/EngineContext'
 import { useEffect } from 'react'
-import emoji from 'react-easy-emoji'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -12,7 +11,7 @@ import { useSimulationProgress } from '../../../components/utils/useNextQuestion
 import { conferenceElementsAdapter } from './Conference'
 import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
-import { CountDisc, CountSection } from './SurveyBar'
+import { CountDisc, CountSection, EmojiStyle } from './SurveyBar'
 import useYjs from './useYjs'
 import { defaultProgressMin, defaultThreshold, getElements } from './utils'
 
@@ -64,6 +63,7 @@ export default () => {
 		defaultProgressMin
 	).length
 
+	//TODO mutualise this display part with SurveyBar
 	return (
 		<Link to={'/conférence/' + conference.room} css="text-decoration: none;">
 			<div
@@ -95,17 +95,19 @@ export default () => {
 					«&nbsp;{conference.room}&nbsp;»
 				</span>
 				<span>
-					{emoji('🧮')} {result}
+					<EmojiStyle>🧮</EmojiStyle>
+					{result}
 				</span>
 				<CountSection>
 					{rawNumber != null && (
 						<span title={t('Nombre total de participants')}>
-							{emoji('👥')} <CountDisc color="#55acee">{rawNumber}</CountDisc>
+							<EmojiStyle>👥</EmojiStyle>
+							<CountDisc color="#55acee">{rawNumber}</CountDisc>
 						</span>
 					)}
 					{completedTestNumber != null && (
 						<span title={t('Nombre de tests terminés')}>
-							{emoji('✅')}
+							<EmojiStyle>✅</EmojiStyle>
 							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
 						</span>
 					)}

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -9,12 +9,16 @@ import { situationSelector } from 'Selectors/simulationSelectors'
 import * as Y from 'yjs'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
+import { conferenceElementsAdapter } from './Conference'
 import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
+import { CountDisc, CountSection } from './SurveyBar'
 import useYjs from './useYjs'
+import { defaultProgressMin, defaultThreshold, getElements } from './utils'
 
 export default () => {
-	const translation = useTranslation()
+	const translation = useTranslation(),
+		t = translation.t
 
 	const situation = useSelector(situationSelector),
 		engine = useEngine(),
@@ -50,6 +54,16 @@ export default () => {
 			simulationArray.map((el) => el.total)
 		)
 
+	const statElements = conferenceElementsAdapter(elements)
+	const rawNumber = getElements(statElements, defaultThreshold, null, 0).length
+
+	const completedTestNumber = getElements(
+		statElements,
+		defaultThreshold,
+		null,
+		defaultProgressMin
+	).length
+
 	return (
 		<Link to={'/conférence/' + conference.room} css="text-decoration: none;">
 			<div
@@ -83,23 +97,19 @@ export default () => {
 				<span>
 					{emoji('🧮')} {result}
 				</span>
-				<span>
-					{emoji('👥')}{' '}
-					<span
-						css={`
-							background: #78b159;
-							width: 1.5rem;
-							height: 1.5rem;
-							border-radius: 2rem;
-							display: inline-block;
-							line-height: 1.5rem;
-							color: var(--darkerColor);
-							text-align: center;
-						`}
-					>
-						{users.length}
-					</span>
-				</span>
+				<CountSection>
+					{rawNumber != null && (
+						<span title={t('Nombre total de participants')}>
+							{emoji('👥')} <CountDisc color="#55acee">{rawNumber}</CountDisc>
+						</span>
+					)}
+					{completedTestNumber != null && (
+						<span title={t('Nombre de tests terminés')}>
+							{emoji('✅')}
+							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
+						</span>
+					)}
+				</CountSection>
 			</div>
 		</Link>
 	)

--- a/source/sites/publicodes/conference/Instructions.tsx
+++ b/source/sites/publicodes/conference/Instructions.tsx
@@ -243,14 +243,6 @@ export default ({
 					</>
 				) : (
 					<>
-						<p>
-							<Trans
-								i18nKey={`publicodes.conference.Instructions.liensSimulationSondage`}
-							>
-								Les participants doivent venir faire leur simulation sur ce
-								lien.
-							</Trans>
-						</p>
 						<Link to={'/simulateur/bilan'}>
 							<button className="ui__ button plain">
 								{t(`Faites votre test`)}

--- a/source/sites/publicodes/conference/Instructions.tsx
+++ b/source/sites/publicodes/conference/Instructions.tsx
@@ -44,7 +44,7 @@ export default ({
 					<p>
 						Le test d'empreinte climat est individuel, mais nous vous proposons
 						ici de le faire à plusieurs. Chacun sera derrière son écran, mais
-						visualisera en temps-réel les résultats des autres.
+						visualisera en temps réel les résultats des autres.
 					</p>
 					<p>
 						C'est l'occasion de se confronter aux autres et de réfléchir

--- a/source/sites/publicodes/conference/Instructions.tsx
+++ b/source/sites/publicodes/conference/Instructions.tsx
@@ -47,8 +47,8 @@ export default ({
 						visualisera en temps réel les résultats des autres.
 					</p>
 					<p>
-						C'est l'occasion de se confronter aux autres et de réfléchir
-						ensemble aux enjeux de notre propre impact.
+						C'est l'occasion de réfléchir ensemble aux enjeux de notre propre
+						impact en comparant nos modes de vie.
 					</p>
 				</Trans>
 			)}

--- a/source/sites/publicodes/conference/NoSurveyCreatedWarning.tsx
+++ b/source/sites/publicodes/conference/NoSurveyCreatedWarning.tsx
@@ -1,0 +1,29 @@
+import { Trans } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import IllustratedMessage from '../../../components/ui/IllustratedMessage'
+
+export default () => (
+	<IllustratedMessage
+		emoji="⚠️"
+		message={
+			<>
+				<p>
+					<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning1">
+						Attention, il n'existe aucun ce sondage à cette adresse. Pour lancer
+						un sondage, l'organisateur doit d'abord le créer sur la page du{' '}
+						<Link to="/groupe">mode groupe</Link>.
+					</Trans>
+				</p>
+				<p>
+					💡{' '}
+					<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning2">
+						Peut-être avez-vous fait une faute de frappe dans l'adresse du
+						sondage ? Pensez notamment à bien respecter les majuscules, à copier
+						coller l'adresse exacte ou à utiliser le QR code.
+					</Trans>
+				</p>
+			</>
+		}
+		backgroundcolor={'var(--lighterColor)'}
+	/>
+)

--- a/source/sites/publicodes/conference/NoSurveyCreatedWarning.tsx
+++ b/source/sites/publicodes/conference/NoSurveyCreatedWarning.tsx
@@ -9,8 +9,8 @@ export default () => (
 			<>
 				<p>
 					<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning1">
-						Attention, il n'existe aucun ce sondage à cette adresse. Pour lancer
-						un sondage, l'organisateur doit d'abord le créer sur la page du{' '}
+						Attention, il n'existe aucun sondage à cette adresse. Pour lancer un
+						sondage, l'organisateur doit d'abord le créer sur la page du{' '}
 						<Link to="/groupe">mode groupe</Link>.
 					</Trans>
 				</p>

--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -192,9 +192,11 @@ export default ({
 							`}
 						>
 							<p>
-								Chaque bare verticale ☝️ est le score total d'un participant,
-								<br />
-								chaque disque 👇️ un score sur une catégorie.
+								<Trans i18nKey="site.publicodes.conferences.Stats.explication0">
+									Chaque barre verticale ☝️ est le score total d'un participant,
+									<br />
+									chaque disque 👇️ un score sur une catégorie.
+								</Trans>
 							</p>
 						</div>
 

--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -26,8 +26,8 @@ export const computeHumanMean = ({ t, i18n }, simulationArray) => {
 }
 
 export default ({
-	totalElements,
-	elements: rawElements,
+	totalElements: totalElementsRaw,
+	elements: elementsRaw,
 	users = [],
 	username: currentUser,
 	threshold,
@@ -39,13 +39,14 @@ export default ({
 
 	const [contextFilter, setContextFilter] = useState({})
 
-	const elements = filterElements(rawElements, contextFilter)
+	const totalElements = filterElements(totalElementsRaw, contextFilter)
+	const elements = filterElements(elementsRaw, contextFilter)
 
 	const [spotlight, setSpotlightRaw] = useState(currentUser)
 
 	const setSpotlight = (username) =>
 		spotlight === username ? setSpotlightRaw(null) : setSpotlightRaw(username)
-	const values = elements.map((el) => el.total)
+	const values = totalElements.map((el) => el.total)
 	const mean = computeMean(values),
 		humanMean = computeHumanMean({ t, i18n }, values)
 
@@ -55,7 +56,7 @@ export default ({
 	if (isNaN(mean)) return null
 
 	const categories = reduceCategories(
-			elements.map(({ byCategory, username }) => [username, byCategory])
+			totalElements.map(({ byCategory, username }) => [username, byCategory])
 		),
 		maxCategory = Object.values(categories).reduce(
 			(memo, next) => Math.max(memo, ...next.map((el) => el.value)),
@@ -71,10 +72,12 @@ export default ({
 		(total / 1000).toLocaleString(currentLangInfos.abrvLocale, {
 			maximumSignificantDigits: 2,
 		})
-	const spotlightElement = elements.find((el) => el.username === spotlight),
+	const spotlightElement = totalElements.find(
+			(el) => el.username === spotlight
+		),
 		spotlightValue = spotlightElement && formatTotal(spotlightElement.total)
 
-	const plural = elements.length > 1 ? 's' : ''
+	const plural = totalElements.length > 1 ? 's' : ''
 	return (
 		<div>
 			<div css=" text-align: center">

--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -77,7 +77,7 @@ export default ({
 		),
 		spotlightValue = spotlightElement && formatTotal(spotlightElement.total)
 
-	const plural = totalElements.length > 1 ? 's' : ''
+	const plural = elements.length > 1 ? 's' : ''
 	return (
 		<div>
 			<div css=" text-align: center">

--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -26,6 +26,7 @@ export const computeHumanMean = ({ t, i18n }, simulationArray) => {
 }
 
 export default ({
+	totalElements,
 	elements: rawElements,
 	users = [],
 	username: currentUser,
@@ -48,7 +49,7 @@ export default ({
 	const mean = computeMean(values),
 		humanMean = computeHumanMean({ t, i18n }, values)
 
-	const progressList = elements.map((el) => el.progress),
+	const progressList = totalElements.map((el) => el.progress),
 		meanProgress = computeMean(progressList)
 
 	if (isNaN(mean)) return null
@@ -73,14 +74,15 @@ export default ({
 	const spotlightElement = elements.find((el) => el.username === spotlight),
 		spotlightValue = spotlightElement && formatTotal(spotlightElement.total)
 
+	const plural = elements.length > 1 ? 's' : ''
 	return (
 		<div>
 			<div css=" text-align: center">
 				<p role="heading" aria-level="2">
 					<Trans>Avancement du groupe</Trans>{' '}
 					<span role="status">
-						({elements.length} participant
-						{elements.length > 1 ? 's' : ''})
+						({elements.length} test{plural} complété{plural} sur{' '}
+						{totalElements.length})
 					</span>
 				</p>
 				<Progress progress={meanProgress} label={t('Avancement du groupe')} />
@@ -253,6 +255,5 @@ const filterElements = (rawElements, contextFilter) =>
 				value === '' ||
 				el.context[key].toLowerCase().includes(value.toLowerCase())
 		)
-		console.log(matches)
 		return matches.every((bool) => bool === true)
 	})

--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -191,32 +191,32 @@ export default ({
 								<br />
 								chaque disque 👇️ un score sur une catégorie.
 							</p>
-							{spotlightValue && spotlight === currentUser ? (
-								<span>
-									<Trans
-										i18nKey={'site.publicodes.conferences.Stats.explication1'}
-									>
-										<span role="status" css="background: #fff45f;">
-											En jaune
-										</span>{' '}
-										: ma simulation à {{ spotlightValue }} t.
-									</Trans>
-								</span>
-							) : (
-								<button
-									className="ui__ link-button"
-									onClick={() => setSpotlight(currentUser)}
-								>
-									<span css="background: #fff45f;">
-										<Trans>Afficher ma simulation</Trans>
-									</span>
-								</button>
-							)}
 						</div>
 
 						<CategoryStats
 							{...{ categories, maxCategory, spotlight, setSpotlight }}
 						/>
+						{spotlightValue && spotlight === currentUser ? (
+							<span>
+								<Trans
+									i18nKey={'site.publicodes.conferences.Stats.explication1'}
+								>
+									<span role="status" css="background: #fff45f;">
+										En jaune
+									</span>{' '}
+									: mon score de {{ spotlightValue }} t.
+								</Trans>
+							</span>
+						) : (
+							<button
+								className="ui__ link-button"
+								onClick={() => setSpotlight(currentUser)}
+							>
+								<span css="background: #fff45f;">
+									<Trans>Afficher mon score</Trans>
+								</span>
+							</button>
+						)}
 					</div>
 				)}
 			</div>

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -3,11 +3,10 @@ import { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import { Trans, useTranslation } from 'react-i18next'
 import { conferenceImg } from '../../../components/SessionBar'
-import IllustratedMessage from '../../../components/ui/IllustratedMessage'
 import Meta from '../../../components/utils/Meta'
 import Navigation from '../Navigation'
 import { useProfileData } from '../Profil'
@@ -15,6 +14,7 @@ import { ConferenceTitle } from './Conference'
 import ContextConversation from './ContextConversation'
 import DataWarning from './DataWarning'
 import Instructions from './Instructions'
+import NoSurveyCreatedWarning from './NoSurveyCreatedWarning'
 import NoTestMessage from './NoTestMessage'
 import Stats from './Stats'
 import { answersURL, surveysURL } from './useDatabase'
@@ -85,29 +85,9 @@ export default () => {
 			/>
 			<h1>Sondage</h1>
 			{isRegisteredSurvey == false && (
-				<IllustratedMessage
-					emoji="⚠️"
-					message={
-						<>
-							<p>
-								<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning1">
-									Attention, il n'existe aucun ce sondage à cette adresse. Pour
-									lancer un sondage, l'organisateur doit d'abord le créer sur la
-									page du <Link to="/groupe">mode groupe</Link>.
-								</Trans>
-							</p>
-							<p>
-								💡{' '}
-								<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning2">
-									Peut-être avez-vous fait une faute de frappe dans l'adresse du
-									sondage ? Pensez notamment à bien respecter les majuscules, à
-									copier coller l'adresse exacte ou à utiliser le QR code.
-								</Trans>
-							</p>
-						</>
-					}
-					backgroundcolor={'var(--lighterColor)'}
-				/>
+				<div css="margin-bottom: 3rem">
+					<NoSurveyCreatedWarning />
+				</div>
 			)}
 			<ConferenceTitle>
 				<img src={conferenceImg} alt="" />

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -1,4 +1,3 @@
-import { usePersistingState } from 'Components/utils/persistState'
 import { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -218,6 +218,12 @@ const DownloadInteractiveButton = ({ url, isRegisteredSurvey }) => {
 	)
 }
 
+export const surveyElementsAdapter = (items) =>
+	Object.values(items).map((el) => ({
+		...el.data,
+		username: el.id,
+	}))
+
 const Results = ({ room, existContext, contextRules }) => {
 	const [cachedSurveyIds] = usePersistingState('surveyIds', {})
 	const survey = useSelector((state) => state.survey)
@@ -225,11 +231,12 @@ const Results = ({ room, existContext, contextRules }) => {
 	const answerMap = survey.answers
 	const username = cachedSurveyIds[survey.room]
 	if (!answerMap || !Object.values(answerMap) || !username) return null
+	const elements = surveyElementsAdapter(answerMap)
 	return (
 		<Stats
-			totalElements={getElements(answerMap, threshold, existContext, 0)}
+			totalElements={getElements(elements, threshold, existContext, 0)}
 			elements={getElements(
-				answerMap,
+				elements,
 				threshold,
 				existContext,
 				defaultProgressMin

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { conferenceImg } from '../../../components/SessionBar'
 import Meta from '../../../components/utils/Meta'
+import { usePersistingState } from '../../../components/utils/persistState'
 import Navigation from '../Navigation'
 import { useProfileData } from '../Profil'
 import { ConferenceTitle } from './Conference'
@@ -259,15 +260,11 @@ const Results = ({ room, existContext, contextRules }) => {
 // In case of survey with context, we only display result with context filled in.
 
 export const getElements = (
-	answerMap,
+	rawElements,
 	threshold,
 	existContext,
 	progressMin
 ) => {
-	const rawElements = Object.values(answerMap).map((el) => ({
-		...el.data,
-		username: el.id,
-	}))
 	const elementsWithinThreshold = rawElements.filter(
 		(el) => el.total > 0 && el.total < threshold && el.progress >= progressMin
 	)

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -227,6 +227,7 @@ const Results = ({ room, existContext, contextRules }) => {
 	if (!answerMap || !Object.values(answerMap) || !username) return null
 	return (
 		<Stats
+			totalElements={getElements(answerMap, threshold, existContext, 0)}
 			elements={getElements(
 				answerMap,
 				threshold,
@@ -256,7 +257,7 @@ export const getElements = (
 		username: el.id,
 	}))
 	const elementsWithinThreshold = rawElements.filter(
-		(el) => el.total > 0 && el.total < threshold && el.progress > progressMin
+		(el) => el.total > 0 && el.total < threshold && el.progress >= progressMin
 	)
 	const elements = existContext
 		? elementsWithinThreshold.filter(

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { Trans, useTranslation } from 'react-i18next'
 import { conferenceImg } from '../../../components/SessionBar'
+import IllustratedMessage from '../../../components/ui/IllustratedMessage'
 import Meta from '../../../components/utils/Meta'
 import Navigation from '../Navigation'
 import { useProfileData } from '../Profil'
@@ -26,7 +27,7 @@ export default () => {
 		{}
 	)
 	const [contextRules, setContextRules] = useState()
-	const [isRegisteredSurvey, setIsRegisteredSurvey] = useState(false)
+	const [isRegisteredSurvey, setIsRegisteredSurvey] = useState(null)
 	const dispatch = useDispatch()
 
 	const { room } = useParams()
@@ -83,6 +84,31 @@ export default () => {
 				}
 			/>
 			<h1>Sondage</h1>
+			{isRegisteredSurvey == false && (
+				<IllustratedMessage
+					emoji="⚠️"
+					message={
+						<>
+							<p>
+								<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning1">
+									Attention, il n'existe aucun ce sondage à cette adresse. Pour
+									lancer un sondage, l'organisateur doit d'abord le créer sur la
+									page du <Link to="/groupe">mode groupe</Link>.
+								</Trans>
+							</p>
+							<p>
+								💡{' '}
+								<Trans i18nKey="publicodes.conference.Survey.notCreatedWarning2">
+									Peut-être avez-vous fait une faute de frappe dans l'adresse du
+									sondage ? Pensez notamment à bien respecter les majuscules, à
+									copier coller l'adresse exacte ou à utiliser le QR code.
+								</Trans>
+							</p>
+						</>
+					}
+					backgroundcolor={'var(--lighterColor)'}
+				/>
+			)}
 			<ConferenceTitle>
 				<img src={conferenceImg} alt="" />
 				<span css="text-transform: uppercase">«&nbsp;{room}&nbsp;»</span>

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -6,7 +6,6 @@ import {
 import { useEngine } from 'Components/utils/EngineContext'
 import { usePersistingState } from 'Components/utils/persistState'
 import { useEffect, useState } from 'react'
-import emoji from 'react-easy-emoji'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -176,20 +175,17 @@ export default () => {
 				`}
 			>
 				<span css="text-transform: uppercase">«&nbsp;{survey.room}&nbsp;»</span>
-				{result && (
-					<span>
-						{emoji('🧮')} {result}
-					</span>
-				)}
+				{result && <span>🧮 {result}</span>}
 				<CountSection>
 					{rawNumber != null && (
 						<span title={t('Nombre total de participants')}>
-							{emoji('👥')} <CountDisc color="#55acee">{rawNumber}</CountDisc>
+							<EmojiStyle>👥</EmojiStyle>
+							<CountDisc color="#55acee">{rawNumber}</CountDisc>
 						</span>
 					)}
 					{completedTestNumber != null && (
 						<span title={t('Nombre de tests terminés')}>
-							{emoji('✅')}
+							<EmojiStyle>✅</EmojiStyle>
 							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
 						</span>
 					)}
@@ -198,6 +194,11 @@ export default () => {
 		</Link>
 	)
 }
+
+export const EmojiStyle = styled.span`
+	font-size: 150%;
+	margin-right: 0.4rem;
+`
 
 export const CountSection = styled.div`
 	display: flex;

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -14,7 +14,6 @@ import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
-import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
 import { surveyElementsAdapter } from './Survey'
 import useDatabase, { answersURL } from './useDatabase'
@@ -151,7 +150,6 @@ export default () => {
 		<Link to={'/sondage/' + survey.room} css="text-decoration: none;">
 			<div
 				css={`
-					${backgroundConferenceAnimation}
 					color: white;
 					padding: 0.3rem 1rem;
 					display: flex;

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -181,13 +181,7 @@ export default () => {
 						{emoji('🧮')} {result}
 					</span>
 				)}
-				<div
-					css={`
-						display: flex;
-						justify-content: space-between;
-						width: 100%;
-					`}
-				>
+				<CountSection>
 					{rawNumber != null && (
 						<span title={t('Nombre total de participants')}>
 							{emoji('👥')} <CountDisc color="#55acee">{rawNumber}</CountDisc>
@@ -199,13 +193,19 @@ export default () => {
 							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
 						</span>
 					)}
-				</div>
+				</CountSection>
 			</div>
 		</Link>
 	)
 }
 
-const CountDisc = styled.span`
+export const CountSection = styled.div`
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+`
+
+export const CountDisc = styled.span`
 	background: ${(props) => props.color};
 	width: 1.5rem;
 	height: 1.5rem;

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -17,6 +17,7 @@ import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
 import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
+import { surveyElementsAdapter } from './Survey'
 import useDatabase, { answersURL } from './useDatabase'
 import { defaultProgressMin, defaultThreshold, getElements } from './utils'
 
@@ -130,15 +131,16 @@ export default () => {
 
 	const existContext = survey ? !(survey['contextFile'] == null) : false
 
+	const elements = surveyElementsAdapter(survey.answers)
 	const rawNumber = getElements(
-		survey.answers,
+		elements,
 		defaultThreshold,
 		existContext,
 		0
 	).length
 
 	const completedTestNumber = getElements(
-		survey.answers,
+		elements,
 		defaultThreshold,
 		existContext,
 		defaultProgressMin

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -11,17 +11,18 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { situationSelector } from 'Selectors/simulationSelectors'
+import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
 import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
-import { getElements } from './Survey'
 import useDatabase, { answersURL } from './useDatabase'
-import { defaultProgressMin, defaultThreshold } from './utils'
+import { defaultProgressMin, defaultThreshold, getElements } from './utils'
 
 export default () => {
-	const translation = useTranslation()
+	const translation = useTranslation(),
+		t = translation.t
 	const situation = useSelector(situationSelector),
 		engine = useEngine(),
 		evaluation = engine.evaluate('bilan'),
@@ -129,14 +130,19 @@ export default () => {
 
 	const existContext = survey ? !(survey['contextFile'] == null) : false
 
-	const elements = getElements(
+	const rawNumber = getElements(
+		survey.answers,
+		defaultThreshold,
+		existContext,
+		0
+	).length
+
+	const completedTestNumber = getElements(
 		survey.answers,
 		defaultThreshold,
 		existContext,
 		defaultProgressMin
-	)
-
-	const answersCount = elements.length
+	).length
 
 	if (DBError) return <div className="ui__ card plain">{DBError}</div>
 
@@ -173,26 +179,37 @@ export default () => {
 						{emoji('🧮')} {result}
 					</span>
 				)}
-				{answersCount != null && (
-					<span>
-						{emoji('👥')}{' '}
-						<span
-							css={`
-								background: #78b159;
-								width: 1.5rem;
-								height: 1.5rem;
-								border-radius: 2rem;
-								display: inline-block;
-								line-height: 1.5rem;
-								text-align: center;
-								color: var(--darkerColor);
-							`}
-						>
-							{answersCount}
+				<div
+					css={`
+						display: flex;
+						justify-content: space-between;
+						width: 100%;
+					`}
+				>
+					{rawNumber != null && (
+						<span title={t('Nombre total de participants')}>
+							{emoji('👥')} <CountDisc color="#55acee">{rawNumber}</CountDisc>
 						</span>
-					</span>
-				)}
+					)}
+					{completedTestNumber != null && (
+						<span title={t('Nombre de tests terminés')}>
+							{emoji('✅')}
+							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
+						</span>
+					)}
+				</div>
 			</div>
 		</Link>
 	)
 }
+
+const CountDisc = styled.span`
+	background: ${(props) => props.color};
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 2rem;
+	display: inline-block;
+	line-height: 1.5rem;
+	text-align: center;
+	color: var(--darkerColor);
+`

--- a/source/sites/publicodes/conference/utils.tsx
+++ b/source/sites/publicodes/conference/utils.tsx
@@ -1,8 +1,8 @@
-import geologicalPeriods from './périodesGéologiques.json'
 import adjectifs from './adjectifs.json'
+import geologicalPeriods from './périodesGéologiques.json'
 // Merci https://github.com/akaAgar/vocabulaire-francais
-import verbs from './participePassés.json'
 import fruits from './fruits.json'
+import verbs from './participePassés.json'
 const periodsCount = geologicalPeriods.length
 const adjectifsCount = adjectifs.length
 const verbsCount = verbs.length
@@ -50,8 +50,6 @@ export const generateRoomName = () => {
 
 export const defaultThreshold = 100 * 1000
 
-export const defaultProgressMin = 0.1
-
 export const filterExtremes = (elements, threshold) =>
 	Object.fromEntries(
 		Object.entries(elements).filter(([_, { total }]) => total < threshold)
@@ -59,3 +57,33 @@ export const filterExtremes = (elements, threshold) =>
 
 export const getExtremes = (elements, threshold) =>
 	Object.entries(elements).filter(([_, { total }]) => total >= threshold)
+
+// Simulations with less than a given progress are excluded, in order to avoid a perturbation of the mean group value by people
+// that did connect to the conference, but did not seriously start the test, hence resulting in multiple default value simulations.
+// In case of survey with context, we only display result with context filled in.
+
+export const defaultProgressMin = 0.9
+// Why 90% ? Because then the test is quite representative with very few default values,
+// and by setting 100% we risk missing some people that unfolded their last question and didn't fold them again
+
+export const getElements = (
+	answerMap,
+	threshold,
+	existContext,
+	progressMin
+) => {
+	const rawElements = Object.values(answerMap).map((el) => ({
+		...el.data,
+		username: el.id,
+	}))
+	const elementsWithinThreshold = rawElements.filter(
+		(el) => el.total > 0 && el.total < threshold && el.progress >= progressMin
+	)
+	const elements = existContext
+		? elementsWithinThreshold.filter(
+				(el) => Object.keys(el.context).length !== 0
+		  )
+		: elementsWithinThreshold
+
+	return elements
+}

--- a/source/sites/publicodes/conference/utils.tsx
+++ b/source/sites/publicodes/conference/utils.tsx
@@ -67,15 +67,11 @@ export const defaultProgressMin = 0.9
 // and by setting 100% we risk missing some people that unfolded their last question and didn't fold them again
 
 export const getElements = (
-	answerMap,
+	rawElements,
 	threshold,
 	existContext,
 	progressMin
 ) => {
-	const rawElements = Object.values(answerMap).map((el) => ({
-		...el.data,
-		username: el.id,
-	}))
 	const elementsWithinThreshold = rawElements.filter(
 		(el) => el.total > 0 && el.total < threshold && el.progress >= progressMin
 	)


### PR DESCRIPTION
> :video_game:  Pas possible de tester le mode sondage en ligne sur la démo, malheureusement :/

> Pour une explication grand public des améliorations, voir le brouillon de release ici https://github.com/datagir/nosgestesclimat/releases/tag/untagged-b699f9073d0a66db27a8

- [x] Déplacement visuel du "ma simulation" renommé en "mon test" sur /groupe
- [x] Sondage : séparation affichage participants et complétés
- [x] implémenter le même comportement pour le mode conférence
- [x] avertissement quand sondage non créé
- [x] mettre l'indicateur "complété" dans la barre latérale de la conférence comme pour le sondage
