### PR TITLE
:bug: Sur l'écran de stats du mode groupe, on affiche tous les éléments

### DIFF
--- a/source/sites/publicodes/conference/Stats.tsx
+++ b/source/sites/publicodes/conference/Stats.tsx
@@ -118,7 +118,7 @@ export default ({
 						</div>
 					</div>
 				</div>
-				{elements.length > 0 && (
+				{totalElements.length > 0 && (
 					<div>
 						<ul
 							title={t('Empreinte totale')}
@@ -134,7 +134,7 @@ export default ({
 								}
 							`}
 						>
-							{elements.map(({ total: value, username }) => (
+							{totalElements.map(({ total: value, username }) => (
 								<li
 									key={username}
 									css={`


### PR DESCRIPTION
Y compris quand le test n'est pas fini. C'était l'objet de la dernière
PR, mais cette partie là m'avait échappé car je testais l'interface
uniquement via les personas, qui sont tous terminés.
