### PR TITLE
🐛 Traduction manquante qui empêche l'ouverture de la sous-catégorie "Voiture" depuis la page "Mon profil"

### DIFF
--- a/source/components/conversation/estimate/AnswerTrajetsTable.js
+++ b/source/components/conversation/estimate/AnswerTrajetsTable.js
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { freqList } from './dataHelp'
 
 export default function AnswerTrajetsTable({ trajets }) {
+	const { t } = useTranslation()
+
 	const trajetsMotif = trajets.reduce((memo, trajet) => {
-		const period = freqList.find((f) => f.name === trajet.periode)
+		const period = freqList(t).find((f) => f.name === trajet.periode)
 		const freqValue = period ? period.value * trajet.xfois : 0
 		const dist = (trajet.distance * freqValue) / trajet.personnes
 


### PR DESCRIPTION
En production, il m'est impossible d'ouvrir la sous-catégorie "Voiture" dans la catégorie "Transport" parce qu'une traduction n'est pas correctement chargée.

Le résultat est une page complètement blanche et une belle erreur dans la console.