### PR TITLE
New mosaic layout

### DIFF
--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -42,7 +42,7 @@ const MenuButton = styled.div`
 	font-size: 110% !important;
 	color: var(--darkColor);
 	padding: 0 0.4rem !important;
-	width: 5rem;
+	width: auto;
 	@media (min-width: 800px) {
 		flex-direction: row;
 		justify-content: start;
@@ -193,6 +193,16 @@ export default function SessionBar({
 				</span>
 			)}
 		</Button>,
+		<Button className="simple small" url="/groupe">
+			<img
+				src={openmojiURL('silhouettes')}
+				css="width: 2rem"
+				aria-hidden="true"
+				width="1"
+				height="1"
+			/>
+			<Trans>Groupe</Trans>
+		</Button>,
 		pullRequestNumber && (
 			<MenuButton key="pullRequest" className="simple small">
 				<a
@@ -231,16 +241,6 @@ export default function SessionBar({
 				</button>
 			</MenuButton>
 		),
-		<Button className="simple small" url="/groupe">
-			<img
-				src={openmojiURL('silhouettes')}
-				css="width: 2rem"
-				aria-hidden="true"
-				width="1"
-				height="1"
-			/>
-			<Trans>Groupe</Trans>
-		</Button>,
 	]
 
 	if (path === '/tutoriel') return null
@@ -262,7 +262,7 @@ export default function SessionBar({
 			`}
 		>
 			{elements.filter(Boolean).length > 0 && (
-				<NavBar>
+				<NavBar isUsingCustomPR={pullRequestNumber != undefined}>
 					{elements.filter(Boolean).map((Comp, i) => (
 						<li key={i}>{Comp}</li>
 					))}
@@ -272,11 +272,15 @@ export default function SessionBar({
 	)
 }
 
-const NavBar = styled.ul`
-	display: flex;
+const NavBar = styled.ul<{ isUsingCustomPR: any }>`
 	box-shadow: rgb(187 187 187) 2px 2px 10px;
 	list-style-type: none;
-	justify-content: space-evenly !important;
+	display: grid;
+	grid-template-columns: repeat(
+		${({ isUsingCustomPR }) => (isUsingCustomPR ? 5 : 4)},
+		1fr
+	);
+	gap: 0.5rem;
 	align-items: center;
 
 	margin: 0;
@@ -287,6 +291,7 @@ const NavBar = styled.ul`
 	padding: 0;
 
 	@media (min-width: 800px) {
+		display: flex;
 		margin-top: 1rem;
 		flex-direction: column;
 		height: auto;

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -41,7 +41,6 @@ const MenuButton = styled.div`
 	justify-content: center;
 	font-size: 110% !important;
 	color: var(--darkColor);
-	padding: 0 0.4rem !important;
 	width: auto;
 	@media (min-width: 800px) {
 		flex-direction: row;
@@ -82,8 +81,10 @@ const Button = (props) => {
 				font-weight: bold;
 				background: var(--lighterColor);
 				display: block;
-				@media (max-width: 800px){border-radius: 1.6rem}
 
+				@media (max-width: 800px) {
+					border-radius: 0.6rem;
+				}
 				`}
 			`}
 			{...(isCurrent
@@ -280,7 +281,6 @@ const NavBar = styled.ul<{ isUsingCustomPR: any }>`
 		${({ isUsingCustomPR }) => (isUsingCustomPR ? 5 : 4)},
 		1fr
 	);
-	gap: 0.5rem;
 	align-items: center;
 
 	margin: 0;
@@ -288,7 +288,7 @@ const NavBar = styled.ul<{ isUsingCustomPR: any }>`
 	height: 4rem;
 	background: white;
 	justify-content: center;
-	padding: 0;
+	padding: 0rem 0.3rem;
 
 	@media (min-width: 800px) {
 		display: flex;
@@ -298,6 +298,8 @@ const NavBar = styled.ul<{ isUsingCustomPR: any }>`
 		background: none;
 		justify-content: start;
 		box-shadow: none;
+		padding: 0;
+
 		li {
 			width: 100%;
 		}

--- a/source/components/Stamp.tsx
+++ b/source/components/Stamp.tsx
@@ -10,14 +10,17 @@ const Stamp = styled.button`
 	font-family: 'Courier';
 	mix-blend-mode: multiply;
 	border: 3px solid var(--color);
-	color: var(--color);
+	color: grey;
 	mask-position: 13rem 6rem;
 	transform: rotate(-10deg);
 	border-radius: 4px;
-	top: 2.5rem;
-	left: 1em;
+	right: 2.5rem;
 	line-height: 1rem;
 	${({ clickable }) => clickable && `cursor: pointer`}
+
+	@media (min-width: 600px) {
+		right: 0%;
+	}
 `
 
 export default Stamp

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -18,7 +18,6 @@ export default function NumberedMosaic({
 	options: { chipsTotal },
 	suggestions,
 }) {
-	const dispatch = useDispatch()
 	const situation = useSelector(situationSelector)
 	const engine = useEngine()
 
@@ -53,85 +52,43 @@ export default function NumberedMosaic({
 								className="ui__ card interactive"
 								key={question.dottedName}
 								id={`card - ${question.dottedName}`}
-								css={`
-									@media (max-width: 800px) {
-										display: flex;
-									}
-								`}
 							>
-								<MosaicLabel htmlFor={question.dottedName}>{title}</MosaicLabel>
-
-								<figure
-									css={`
-										${!description ? 'font-size: 200%' : ''}
-									`}
-								>
-									{icônes}
-								</figure>
-								<p id={'description ' + title}>
-									{description && description.split('\n')[0]}
-								</p>
 								<div
 									css={`
-										span {
-											margin: 0.8rem;
-											font-size: 120%;
-										}
+										display: flex;
+										flex-direction: column;
+										align-items: flex-start;
 									`}
 								>
-									<button
-										className={`ui__ button small plain ${
-											!value ? 'disabled' : ''
-										}`}
-										onClick={() =>
-											value > 0 &&
-											dispatch(updateSituation(question.dottedName, value - 1))
-										}
-										title={t(`Enlever `) + title.toLowerCase()}
-									>
-										-
-									</button>
-									<NumberFormat
-										inputMode="decimal"
-										allowNegative={false}
-										decimalScale={0}
-										aria-describedby={'description ' + title}
-										id={question.dottedName}
+									<MosaicLabel htmlFor={question.dottedName}>
+										<span
+											css={`
+												font-size: 100%;
+
+												@media (max-width: 800px) {
+												}
+											`}
+										>
+											{icônes}
+										</span>
+										{title}
+									</MosaicLabel>
+									<p
+										id={'description ' + title}
 										css={`
-											width: 1.5rem;
-											padding: 0; /* Necessary for iPhone Safari 7-12 at least */
-											height: 1.5rem;
-											font-size: 100%;
-											color: var(--darkColor);
-											margin: 0 0.6rem;
-											text-align: center;
-											border: none;
-											border-bottom: 2px dotted var(--color);
+											text-align: left !important;
 										`}
-										value={
-											situationValue == null
-												? undefined
-												: situationValue === 0 // if situation value is 0 (2 options : input is filled in with a 0 or input is empty), value become an empty string and placeholder (0) is visible..
-												? ''
-												: value
-										}
-										placeholder={value}
-										onChange={(e) =>
-											dispatch(
-												updateSituation(question.dottedName, +e.target.value)
-											)
-										}
-									/>
-									<button
-										className="ui__ button small plain"
-										onClick={() =>
-											dispatch(updateSituation(question.dottedName, value + 1))
-										}
-										title={t(`Ajouter `) + title.toLowerCase()}
 									>
-										+
-									</button>
+										{description && description.split('\n')[0]}
+									</p>
 								</div>
+								<NumericInputWithButtons
+									name={name}
+									question={question}
+									title={title}
+									value={value}
+									situationValue={situationValue}
+								/>
 							</li>
 						)
 					}
@@ -188,12 +145,104 @@ export default function NumberedMosaic({
 }
 
 export const mosaicLabelStyle = `
-	text-align: center;
+	text-align: left;
 	line-height: 1.2rem;
 	margin-top: 0.6rem;
 	margin-bottom: 0.4rem;
 	font-weight: bold;
+	white-space: nowrap;
 `
 const MosaicLabel = styled.label`
 	${mosaicLabelStyle}
 `
+const NumericButton = styled.button`
+	font-size: 100%;
+	font-weight: bold;
+	border: solid 1px var(--color);
+	border-radius: 0.2rem;
+	background-color: var(--color);
+	color: white;
+	padding: 0;
+	width: 90%;
+	height: fit;
+
+	&:not(:disabled):hover {
+		transform: scale(1.1, 1.1);
+	}
+
+	&:disabled {
+		color: gray;
+		background-color: transparent;
+	}
+`
+
+function NumericInputWithButtons({
+	name,
+	question,
+	title,
+	value,
+	situationValue,
+}) {
+	const dispatch = useDispatch()
+	const { t } = useTranslation()
+
+	return (
+		<div
+			css={`
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				align-items: center;
+				margin: 0;
+			`}
+		>
+			<NumericButton
+				onClick={() =>
+					dispatch(updateSituation(question.dottedName, value + 1))
+				}
+				title={t(`Ajouter `) + title.toLowerCase()}
+			>
+				+
+			</NumericButton>
+			<NumberFormat
+				inputMode="decimal"
+				allowNegative={false}
+				decimalScale={0}
+				aria-describedby={'description ' + title}
+				id={question.dottedName}
+				css={`
+					width: 1.3rem;
+					padding: 0; /* Necessary for iPhone Safari 7-12 at least */
+					height: 1rem;
+					font-size: 100%;
+					color: var(--darkColor);
+					margin: 0.3rem 0.1rem;
+					text-align: center;
+					border: none;
+					color: var(--darkColor);
+				`}
+				value={
+					situationValue == null
+						? undefined
+						: situationValue === 0 // if situation value is 0 (2 options : input is filled in with a 0 or input is empty), value become an empty string and placeholder (0) is visible..
+						? ''
+						: value
+				}
+				placeholder={value}
+				onChange={(e) =>
+					dispatch(updateSituation(question.dottedName, +e.target.value))
+				}
+			/>
+			<NumericButton
+				className={!value ? 'disabled' : ''}
+				disabled={!value}
+				onClick={() =>
+					value > 0 && dispatch(updateSituation(question.dottedName, value - 1))
+				}
+				title={t(`Enlever `) + title.toLowerCase()}
+			>
+				-
+			</NumericButton>
+		</div>
+	)
+}

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -129,8 +129,8 @@ const NumericButton = styled.button`
 	background-color: var(--color);
 	color: white;
 	padding: 0;
-	width: 2.3rem;
-	height: 1.6rem;
+	width: 2rem;
+	height: 2rem;
 
 	&:not(:disabled):hover {
 		transform: scale(1.1, 1.1);
@@ -156,20 +156,22 @@ function NumericInputWithButtons({
 		<div
 			css={`
 				display: flex;
-				flex-direction: column;
+				flex-direction: row;
 				justify-content: center;
 				align-items: center;
 				margin: 0;
 			`}
 		>
-			<NumericButton
+			<button
+				className={'ui__ button small plain ' + (!value ? 'disabled' : '')}
+				disabled={!value}
 				onClick={() =>
-					dispatch(updateSituation(question.dottedName, value + 1))
+					value > 0 && dispatch(updateSituation(question.dottedName, value - 1))
 				}
-				title={t(`Ajouter `) + title.toLowerCase()}
+				title={t(`Enlever `) + title.toLowerCase()}
 			>
-				+
-			</NumericButton>
+				-
+			</button>
 			<NumberFormat
 				inputMode="decimal"
 				allowNegative={false}
@@ -182,7 +184,7 @@ function NumericInputWithButtons({
 					height: 1rem;
 					font-size: 100%;
 					color: var(--darkColor);
-					margin: 0.3rem 0.1rem;
+					margin: 0.3rem 0.3rem;
 					text-align: center;
 					border: none;
 					color: var(--darkColor);
@@ -199,16 +201,15 @@ function NumericInputWithButtons({
 					dispatch(updateSituation(question.dottedName, +e.target.value))
 				}
 			/>
-			<NumericButton
-				className={!value ? 'disabled' : ''}
-				disabled={!value}
+			<button
+				className="ui__ button small plain"
 				onClick={() =>
-					value > 0 && dispatch(updateSituation(question.dottedName, value - 1))
+					dispatch(updateSituation(question.dottedName, value + 1))
 				}
-				title={t(`Enlever `) + title.toLowerCase()}
+				title={t(`Ajouter `) + title.toLowerCase()}
 			>
-				-
-			</NumericButton>
+				+
+			</button>
 		</div>
 	)
 }

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -159,7 +159,7 @@ function NumericInputWithButtons({
 				flex-direction: row;
 				justify-content: center;
 				align-items: center;
-				margin: 0;
+				margin-left: 0.6rem;
 			`}
 		>
 			<button

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -6,7 +6,7 @@ import { situationSelector } from 'Selectors/simulationSelectors'
 import styled from 'styled-components'
 import { useEngine } from '../../utils/EngineContext'
 import MosaicInputSuggestions from '../MosaicInputSuggestions'
-import { Mosaic } from './UI'
+import { Mosaic, MosaicItemLabel } from './UI'
 
 export default function NumberedMosaic({
 	name,
@@ -53,35 +53,12 @@ export default function NumberedMosaic({
 								key={question.dottedName}
 								id={`card - ${question.dottedName}`}
 							>
-								<div
-									css={`
-										display: flex;
-										flex-direction: column;
-										align-items: flex-start;
-									`}
-								>
-									<MosaicLabel htmlFor={question.dottedName}>
-										<span
-											css={`
-												font-size: 100%;
-
-												@media (max-width: 800px) {
-												}
-											`}
-										>
-											{icônes}
-										</span>
-										{title}
-									</MosaicLabel>
-									<p
-										id={'description ' + title}
-										css={`
-											text-align: left !important;
-										`}
-									>
-										{description && description.split('\n')[0]}
-									</p>
-								</div>
+								<MosaicItemLabel
+									question={question}
+									title={title}
+									icônes={icônes}
+									description={description}
+								/>
 								<NumericInputWithButtons
 									name={name}
 									question={question}

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -1,5 +1,4 @@
 import { updateSituation } from 'Actions/actions'
-import emoji from 'react-easy-emoji'
 import { useTranslation } from 'react-i18next'
 import NumberFormat from 'react-number-format'
 import { useDispatch, useSelector } from 'react-redux'
@@ -54,20 +53,32 @@ export default function NumberedMosaic({
 								className="ui__ card interactive"
 								key={question.dottedName}
 								id={`card - ${question.dottedName}`}
+								css={`
+									@media (max-width: 800px) {
+										display: flex;
+									}
+								`}
 							>
 								<MosaicLabel htmlFor={question.dottedName}>{title}</MosaicLabel>
 
-								<div
+								<figure
 									css={`
 										${!description ? 'font-size: 200%' : ''}
 									`}
 								>
-									{icônes && emoji(icônes)}
-								</div>
+									{icônes}
+								</figure>
 								<p id={'description ' + title}>
 									{description && description.split('\n')[0]}
 								</p>
-								<div css={' span {margin: .8rem; font-size: 120%}'}>
+								<div
+									css={`
+										span {
+											margin: 0.8rem;
+											font-size: 120%;
+										}
+									`}
+								>
 									<button
 										className={`ui__ button small plain ${
 											!value ? 'disabled' : ''
@@ -140,7 +151,7 @@ export default function NumberedMosaic({
 							})}
 						</p>
 					) : chipsCount === chipsTotal ? (
-						<p role="alert">{emoji('😋👍')}</p>
+						<p role="alert">😋👍</p>
 					) : (
 						<p
 							role="alert"

--- a/source/components/conversation/select/NumberedMosaic.tsx
+++ b/source/components/conversation/select/NumberedMosaic.tsx
@@ -121,17 +121,6 @@ export default function NumberedMosaic({
 	)
 }
 
-export const mosaicLabelStyle = `
-	text-align: left;
-	line-height: 1.2rem;
-	margin-top: 0.6rem;
-	margin-bottom: 0.4rem;
-	font-weight: bold;
-	white-space: nowrap;
-`
-const MosaicLabel = styled.label`
-	${mosaicLabelStyle}
-`
 const NumericButton = styled.button`
 	font-size: 100%;
 	font-weight: bold;
@@ -140,8 +129,8 @@ const NumericButton = styled.button`
 	background-color: var(--color);
 	color: white;
 	padding: 0;
-	width: 90%;
-	height: fit;
+	width: 2.3rem;
+	height: 1.6rem;
 
 	&:not(:disabled):hover {
 		transform: scale(1.1, 1.1);

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -1,14 +1,13 @@
 import { updateSituation } from 'Actions/actions'
 import Checkbox from 'Components/ui/Checkbox'
-import emoji from 'react-easy-emoji'
+import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { situationSelector } from 'Selectors/simulationSelectors'
-import { Mosaic } from './UI'
-import Stamp from '../../Stamp'
-import { mosaicLabelStyle } from './NumberedMosaic'
 import styled from 'styled-components'
+import Stamp from '../../Stamp'
 import MosaicInputSuggestions from '../MosaicInputSuggestions'
-import { Trans } from 'react-i18next'
+import { mosaicLabelStyle } from './NumberedMosaic'
+import { Mosaic, MosaicItemLabel } from './UI'
 
 const MosaicLabelDiv = styled.div`
 	${mosaicLabelStyle}
@@ -58,23 +57,22 @@ export default function SelectDevices({
 							isNotActive = question.rawNode['inactif']
 						return (
 							<li
-								css={`
-									padding: 2rem;
-									position: relative;
-									pointer-events: none;
-								`}
 								className={
 									isNotActive
-										? `ui__ card light-border inactive`
-										: `ui__ card interactive light-border ${
+										? `ui__ card interactive inactive`
+										: `ui__ card interactive ${
 												value === 'oui' ? `selected` : ''
 										  }`
 								}
 								key={name}
 							>
-								{icônes && <div css="font-size: 150%">{emoji(icônes)}</div>}
-								<MosaicLabelDiv>{title}</MosaicLabelDiv>
-								{false && description && <p>{description.split('\n')[0]}</p>}
+								<MosaicItemLabel
+									question={question}
+									title={title}
+									icônes={icônes}
+									description={false}
+									isNotActive={isNotActive}
+								/>
 								{!isNotActive && (
 									<div
 										css={`
@@ -101,16 +99,12 @@ export default function SelectDevices({
 								{isNotActive && (
 									<Stamp
 										css={`
-											z-index: 1;
+											z-index: 0;
 											max-width: 8rem;
 											text-align: center;
-											border: 2px solid var(--darkColor);
+											border: 3px solid var(--darkColor);
 											color: var(--darkColor);
-											font-size: 90%;
-											@media (min-width: 800px) {
-												left: 3rem;
-												top: 4rem;
-											}
+											font-size: 10%;
 										`}
 									>
 										<Trans>Bientôt disponible !</Trans>

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -26,6 +26,9 @@ export default function SelectDevices({
 		[]
 	)
 
+	// we want to sort the cards so that the inactive ones are at the end
+	selectedRules.sort(([{ _ }, q], [_b]) => ('inactif' in q.rawNode ? 1 : -1))
+
 	// for now, if nothing is checked, after having check something, 'suivant' button will have same effect as 'je ne sais pas'
 	// we can imagine a useeffect that set to 0 situation of dottedname every time all card are unchecked (after user checked something at least once)
 
@@ -54,7 +57,7 @@ export default function SelectDevices({
 									: // unlike the NumberedMosaic, we don't preselect cards choices here
 									  // user tests showed us it is now well received
 									  'non',
-							isNotActive = question.rawNode['inactif']
+							isNotActive = 'inactif' in question.rawNode
 						return (
 							<li
 								className={

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -62,7 +62,7 @@ export default function SelectDevices({
 								className={
 									isNotActive
 										? `ui__ card interactive inactive`
-										: `ui__ card interactive ${
+										: `ui__ card interactive transparent-border ${
 												value === 'oui' ? `selected` : ''
 										  }`
 								}

--- a/source/components/conversation/select/SelectDevices.tsx
+++ b/source/components/conversation/select/SelectDevices.tsx
@@ -6,8 +6,7 @@ import { situationSelector } from 'Selectors/simulationSelectors'
 import styled from 'styled-components'
 import Stamp from '../../Stamp'
 import MosaicInputSuggestions from '../MosaicInputSuggestions'
-import { mosaicLabelStyle } from './NumberedMosaic'
-import { Mosaic, MosaicItemLabel } from './UI'
+import { Mosaic, MosaicItemLabel, mosaicLabelStyle } from './UI'
 
 const MosaicLabelDiv = styled.div`
 	${mosaicLabelStyle}

--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const Mosaic = styled.ul`
 	display: flex;
 	flex-direction: column;
-	justify-content: space-evenly;
+	justify-content: flex-start;
 	flex-wrap: wrap;
 	padding: 0;
 
@@ -32,7 +32,7 @@ export const Mosaic = styled.ul`
 		> li {
 			width: 48%;
 			padding: 0.6rem;
-			margin: 0.3rem 0;
+			margin: 0.3rem 0.3rem;
 		}
 		figure {
 			order: -1;

--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -2,9 +2,11 @@ import styled from 'styled-components'
 
 export const Mosaic = styled.ul`
 	display: flex;
+	flex-direction: column;
 	justify-content: space-evenly;
 	flex-wrap: wrap;
 	padding: 0;
+
 	p {
 		text-align: center;
 	}
@@ -15,26 +17,22 @@ export const Mosaic = styled.ul`
 	}
 
 	> li {
-		width: 14rem;
-		min-height: 10rem;
-		margin: 1rem 0;
+		width: 100%;
+		min-height: initial;
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
 		justify-content: space-between;
 		align-items: center;
-		padding-bottom: 1rem;
+		padding: 0.3rem;
+		margin: 0.3rem 0;
 	}
 
-	@media (max-width: 800px) {
-		display: flex;
-		flex-direction: column;
+	@media (min-width: 600px) {
+		flex-direction: row;
 		> li {
-			width: 100%;
-			display: flex;
-			flex-direction: row;
-			min-height: initial;
+			width: 48%;
 			padding: 0.6rem;
-			margin: 0.6rem 0;
+			margin: 0.3rem 0;
 		}
 		figure {
 			order: -1;

--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -26,8 +26,20 @@ export const Mosaic = styled.ul`
 	}
 
 	@media (max-width: 800px) {
+		display: flex;
+		flex-direction: column;
 		> li {
-			width: 10rem;
+			width: 100%;
+			display: flex;
+			flex-direction: row;
+			min-height: initial;
+			padding: 0.6rem;
+			margin: 0.6rem 0;
+		}
+		figure {
+			order: -1;
+			margin: 0;
+			font-size: 160%;
 		}
 	}
 

--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -51,3 +51,53 @@ export const Mosaic = styled.ul`
 		line-height: 1.2rem;
 	}
 `
+
+export function MosaicItemLabel({
+	question,
+	title,
+	icônes,
+	description,
+	isNotActive,
+}) {
+	return (
+		<div
+			css={`
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+			`}
+		>
+			<MosaicLabel htmlFor={question.dottedName} isNotActive={isNotActive}>
+				<span
+					css={`
+						font-size: 100%;
+						margin-right: 0.3rem;
+					`}
+				>
+					{icônes}
+				</span>
+				{title}
+			</MosaicLabel>
+			<p
+				id={'description ' + title}
+				css={`
+					text-align: left !important;
+				`}
+			>
+				{description && description.split('\n')[0]}
+			</p>
+		</div>
+	)
+}
+
+export const mosaicLabelStyle = `
+	text-align: left;
+	line-height: 1.2rem;
+	margin-top: 0.6rem;
+	margin-bottom: 0.4rem;
+	font-weight: bold;
+`
+const MosaicLabel = styled.label`
+	${({ isNotActive }) => (isNotActive ? 'opacity: 0.75;' : '')}
+	${mosaicLabelStyle}
+`

--- a/source/components/conversation/select/UI.js
+++ b/source/components/conversation/select/UI.js
@@ -27,7 +27,7 @@ export const Mosaic = styled.ul`
 		margin: 0.3rem 0;
 	}
 
-	@media (min-width: 600px) {
+	@media (min-width: 800px) {
 		flex-direction: row;
 		> li {
 			width: 48%;
@@ -100,4 +100,6 @@ export const mosaicLabelStyle = `
 const MosaicLabel = styled.label`
 	${({ isNotActive }) => (isNotActive ? 'opacity: 0.75;' : '')}
 	${mosaicLabelStyle}
+	display: flex;
+	flex-wrap: wrap;
 `

--- a/source/components/ui/index.css
+++ b/source/components/ui/index.css
@@ -92,6 +92,11 @@ blockquote {
 	border-radius: 0.3rem;
 }
 
+.ui__.transparent-border {
+	border: 4px solid transparent;
+	border-radius: 0.3rem;
+}
+
 .ui__.center-flex {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
New horizontal layout for mosaics in order to manage more items inside mosaics.

## Changelog

* New horizontal layout for mosaic question + some UI factorisation between the `NumberedMosaic` and `SelectDevices` components
* Better width management of the navbar buttons -- https://github.com/datagir/nosgestesclimat-site/pull/855/commits/747a9b56fc154a1260291b04616ea885f8c85df6
* Put inactive cards at the end of the list -- https://github.com/datagir/nosgestesclimat-site/pull/855/commits/f4a8d6192e04c01b81ca31708cc3323c2a7eadc5#885