### PR TITLE
Navigation mode groupe

### DIFF
--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -78,7 +78,17 @@ const Button = (props) => {
 	return (
 		<Link
 			to={props.url}
-			css="text-decoration: none"
+			css={`
+				text-decoration: none;
+				${isCurrent &&
+				`
+				font-weight: bold;
+				background: var(--lighterColor);
+				display: block;
+				@media (max-width: 800px){border-radius: 1.6rem}
+
+				`}
+			`}
 			{...(isCurrent
 				? {
 						'aria-current': 'page',
@@ -140,16 +150,6 @@ export default function SessionBar({
 	const location = useLocation(),
 		path = location.pathname
 
-	const buttonStyle = (pathTarget) =>
-		path.includes(pathTarget)
-			? `
-		font-weight: bold;
-		img, svg {
-		  background: var(--lighterColor);
-		  border-radius: 2rem;
-		}
-		`
-			: ''
 	const persona = useSelector((state) => state.simulation?.persona)
 
 	const [searchParams, setSearchParams] = useSearchParams()
@@ -161,25 +161,15 @@ export default function SessionBar({
 	const { t } = useTranslation()
 
 	let elements = [
-		<Button
-			className="simple small"
-			url="/simulateur/bilan"
-			css={`
-				${buttonStyle('simulateur')};
-			`}
-		>
+		<Button className="simple small" url="/simulateur/bilan">
 			<ProgressCircle />
 			<Trans>Le test</Trans>
 		</Button>,
-		<Button
-			className="simple small"
-			url="/actions/liste"
-			css={buttonStyle('/actions')}
-		>
+		<Button className="simple small" url="/actions/liste">
 			<ActionsInteractiveIcon />
 			<Trans>Agir</Trans>
 		</Button>,
-		<Button className="simple small" url="/profil" css={buttonStyle('profil')}>
+		<Button className="simple small" url="/profil">
 			<div
 				css={`
 					position: relative;
@@ -209,11 +199,7 @@ export default function SessionBar({
 			)}
 		</Button>,
 		pullRequestNumber && (
-			<MenuButton
-				key="pullRequest"
-				className="simple small"
-				css={buttonStyle('github')}
-			>
+			<MenuButton key="pullRequest" className="simple small">
 				<a
 					href={
 						'https://github.com/datagir/nosgestesclimat/pull/' +
@@ -250,13 +236,7 @@ export default function SessionBar({
 				</button>
 			</MenuButton>
 		),
-		<Button
-			className="simple small"
-			url="/groupe"
-			css={`
-				${buttonStyle('silhouettes')};
-			`}
-		>
+		<Button className="simple small" url="/groupe">
 			<img
 				src={openmojiURL('silhouettes')}
 				css="width: 2rem"
@@ -271,7 +251,6 @@ export default function SessionBar({
 				title="Conférence"
 				icon={conferenceImg}
 				url={'/conférence/' + conference.room}
-				buttonStyle={buttonStyle}
 			>
 				<ConferenceBarLazy />
 			</GroupModeMenuEntry>
@@ -281,7 +260,6 @@ export default function SessionBar({
 				title="Sondage"
 				icon={openmojiURL('sondage')}
 				url={'/sondage/' + survey.room}
-				buttonStyle={buttonStyle}
 			>
 				<SurveyBarLazy />
 			</GroupModeMenuEntry>
@@ -348,7 +326,7 @@ const NavBar = styled.ul`
 	}
 `
 
-const GroupModeMenuEntry = ({ title, icon, url, children, buttonStyle }) => {
+const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 	return (
 		<div
 			css={`
@@ -362,7 +340,6 @@ const GroupModeMenuEntry = ({ title, icon, url, children, buttonStyle }) => {
 				className="simple small"
 				url={url}
 				css={`
-					${buttonStyle('conf')}
 					padding: 0.4rem;
 					color: white;
 					img {

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -30,7 +30,7 @@ const openmojis = {
 	conference: '1F3DF',
 	sondage: '1F4CA',
 	profile: 'silhouette',
-	groupe: 'silhouettes',
+	silhouettes: 'silhouettes',
 	personas: '1F465',
 	github: 'E045',
 }
@@ -47,6 +47,7 @@ const MenuButton = styled.div`
 	font-size: 110% !important;
 	color: var(--darkColor);
 	padding: 0 0.4rem !important;
+	width: 6rem;
 	@media (min-width: 800px) {
 		flex-direction: row;
 		justify-content: start;
@@ -210,7 +211,7 @@ export default function SessionBar({
 				)}
 			</div>
 			{!persona ? (
-				t('Mon profil')
+				t('Profil')
 			) : (
 				<span
 					css={`
@@ -266,6 +267,22 @@ export default function SessionBar({
 				</button>
 			</MenuButton>
 		),
+		<Button
+			className="simple small"
+			url="/groupe"
+			css={`
+				${buttonStyle('silhouettes')};
+			`}
+		>
+			<img
+				src={openmojiURL('silhouettes')}
+				css="width: 2rem"
+				aria-hidden="true"
+				width="1"
+				height="1"
+			/>
+			<Trans>Groupe</Trans>
+		</Button>,
 		conference?.room && (
 			<GroupModeMenuEntry
 				title="Conférence"

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -1,5 +1,4 @@
 import { loadPreviousSimulation } from 'Actions/actions'
-import useLocalisation from 'Components/localisation/useLocalisation'
 import { extractCategories } from 'Components/publicodesUtils'
 import { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -14,7 +13,6 @@ import { backgroundConferenceAnimation } from '../sites/publicodes/conference/co
 import SurveyBarLazy from '../sites/publicodes/conference/SurveyBarLazy'
 import { omit } from '../utils'
 import CardGameIcon from './CardGameIcon'
-import { getModelFlag } from './localisation/utils'
 import ProgressCircle from './ProgressCircle'
 import { usePersistingState } from './utils/persistState'
 
@@ -138,9 +136,6 @@ export default function SessionBar({
 	const survey = useSelector((state) => state.survey)
 	const dispatch = useDispatch()
 
-	const localisation = useLocalisation()
-	const flag = getModelFlag(localisation?.country?.code)
-
 	const location = useLocation(),
 		path = location.pathname
 
@@ -196,19 +191,6 @@ export default function SessionBar({
 					width="1"
 					height="1"
 				/>
-				{flag && (
-					<img
-						src={flag}
-						css={`
-							position: absolute;
-							left: 1.45rem;
-							top: -0.15rem;
-							width: 1.2rem;
-							border-radius: 0.3rem !important;
-						`}
-						aria-hidden="true"
-					/>
-				)}
 			</div>
 			{!persona ? (
 				t('Profil')

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -30,6 +30,7 @@ const openmojis = {
 	conference: '1F3DF',
 	sondage: '1F4CA',
 	profile: 'silhouette',
+	groupe: 'silhouettes',
 	personas: '1F465',
 	github: 'E045',
 }
@@ -223,23 +224,6 @@ export default function SessionBar({
 				</span>
 			)}
 		</Button>,
-		NODE_ENV === 'development' && (
-			<Button
-				key="personas"
-				className="simple small"
-				url="/personas"
-				css={buttonStyle('personas')}
-			>
-				<img
-					src={openmojiURL('personas')}
-					css="width: 2rem"
-					aria-hidden="true"
-					width="1"
-					height="1"
-				/>
-				Personas
-			</Button>
-		),
 		pullRequestNumber && (
 			<MenuButton
 				key="pullRequest"

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -60,7 +60,7 @@ const MenuButton = styled.div`
 		}
 		height: auto;
 	}
-	@media (max-height: 700px) {
+	@media (max-height: 600px) {
 		img,
 		svg {
 			display: none;
@@ -298,7 +298,7 @@ const NavBar = styled.ul`
 		}
 	}
 
-	@media (max-height: 700px) {
+	@media (max-height: 600px) {
 		height: 2rem;
 	}
 `

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -51,6 +51,7 @@ const MenuButton = styled.div`
 		justify-content: start;
 		padding: 0;
 		font-size: 100%;
+		width: auto;
 	}
 	img,
 	svg {

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -8,9 +8,6 @@ import { RootState } from 'Reducers/rootReducer'
 import { answeredQuestionsSelector } from 'Selectors/simulationSelectors'
 import styled from 'styled-components'
 import { resetLocalisation } from '../actions/actions'
-import ConferenceBarLazy from '../sites/publicodes/conference/ConferenceBarLazy'
-import { backgroundConferenceAnimation } from '../sites/publicodes/conference/conferenceStyle'
-import SurveyBarLazy from '../sites/publicodes/conference/SurveyBarLazy'
 import { omit } from '../utils'
 import CardGameIcon from './CardGameIcon'
 import ProgressCircle from './ProgressCircle'
@@ -143,8 +140,6 @@ export default function SessionBar({
 }) {
 	useSafePreviousSimulation()
 
-	const conference = useSelector((state) => state.conference)
-	const survey = useSelector((state) => state.survey)
 	const dispatch = useDispatch()
 
 	const location = useLocation(),
@@ -246,24 +241,6 @@ export default function SessionBar({
 			/>
 			<Trans>Groupe</Trans>
 		</Button>,
-		conference?.room && (
-			<GroupModeMenuEntry
-				title="Conférence"
-				icon={conferenceImg}
-				url={'/conférence/' + conference.room}
-			>
-				<ConferenceBarLazy />
-			</GroupModeMenuEntry>
-		),
-		survey?.room && (
-			<GroupModeMenuEntry
-				title="Sondage"
-				icon={openmojiURL('sondage')}
-				url={'/sondage/' + survey.room}
-			>
-				<SurveyBarLazy />
-			</GroupModeMenuEntry>
-		),
 	]
 
 	if (path === '/tutoriel') return null
@@ -325,53 +302,3 @@ const NavBar = styled.ul`
 		height: 2rem;
 	}
 `
-
-const GroupModeMenuEntry = ({ title, icon, url, children }) => {
-	return (
-		<div
-			css={`
-				${backgroundConferenceAnimation}
-				color: white;
-				border-radius: 0.4rem;
-				margin-right: 0.6rem;
-			`}
-		>
-			<Button
-				className="simple small"
-				url={url}
-				css={`
-					padding: 0.4rem;
-					color: white;
-					img {
-						filter: invert(1);
-						background: none;
-						margin: 0 0.6rem 0 0 !important;
-					}
-					@media (max-width: 800px) {
-						img {
-							margin: 0 !important;
-						}
-					}
-				`}
-			>
-				<img
-					src={icon}
-					css="width: 2rem"
-					aria-hidden="true"
-					width="1"
-					height="1"
-				/>
-				{title}
-			</Button>
-			<div
-				css={`
-					@media (max-width: 800px) {
-						display: none;
-					}
-				`}
-			>
-				{children}
-			</div>
-		</div>
-	)
-}

--- a/source/components/SessionBar.tsx
+++ b/source/components/SessionBar.tsx
@@ -42,7 +42,7 @@ const MenuButton = styled.div`
 	font-size: 110% !important;
 	color: var(--darkColor);
 	padding: 0 0.4rem !important;
-	width: 6rem;
+	width: 5rem;
 	@media (min-width: 800px) {
 		flex-direction: row;
 		justify-content: start;

--- a/source/components/localisation/Localisation.tsx
+++ b/source/components/localisation/Localisation.tsx
@@ -17,11 +17,6 @@ export default () => {
 	const localisation = useLocalisation(chosenIp)
 	const dispatch = useDispatch()
 
-	const [messagesRead, setRead] = usePersistingState(
-		'localisationMessagesRead',
-		[]
-	)
-
 	const supportedRegions = useSelector((state) => state.supportedRegions)
 	const isSupported = supportedRegion(localisation?.country?.code)
 	const flag = getFlag(localisation?.country?.code)
@@ -119,7 +114,7 @@ export default () => {
 									userChosen: true,
 								}
 								dispatch(setLocalisation(newLocalisation))
-								setRead([])
+								dispatch({ type: 'SET_LOCALISATION_BANNERS_READ', regions: [] })
 							}}
 						>
 							<button>{capitalise0(nom)}</button>

--- a/source/components/localisation/LocalisationMessage.tsx
+++ b/source/components/localisation/LocalisationMessage.tsx
@@ -118,7 +118,7 @@ export default () => {
 						<small>
 							<Trans>Pas votre région ?</Trans>{' '}
 							<Link to="/profil">
-								<Trans>Choisissez la votre</Trans>
+								<Trans>Choisissez la vôtre</Trans>
 							</Link>
 							.
 						</small>

--- a/source/components/localisation/LocalisationMessage.tsx
+++ b/source/components/localisation/LocalisationMessage.tsx
@@ -1,8 +1,7 @@
 import { Trans } from 'react-i18next'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import IllustratedMessage from '../ui/IllustratedMessage'
-import { usePersistingState } from '../utils/persistState'
 import useLocalisation from './useLocalisation'
 import {
 	defaultModel,
@@ -12,10 +11,10 @@ import {
 	supportedRegion,
 } from './utils'
 export default () => {
-	const [messagesRead, setRead] = usePersistingState(
-		'localisationMessagesRead',
-		[]
+	const messagesRead = useSelector(
+		(state) => state.sessionLocalisationBannersRead
 	)
+	const dispatch = useDispatch()
 	const localisation = useLocalisation()
 	const currentLang = useSelector((state) => state.currentLang)
 	const regionParams = supportedRegion(localisation?.country?.code)
@@ -82,7 +81,10 @@ export default () => {
 							display: block !important;
 						`}
 						onClick={() =>
-							setRead([...messagesRead, localisation?.country?.code])
+							dispatch({
+								type: 'SET_LOCALISATION_BANNERS_READ',
+								regions: [...messagesRead, localisation?.country?.code],
+							})
 						}
 					>
 						<Trans>J'ai compris</Trans>
@@ -130,7 +132,12 @@ export default () => {
 							margin-right: 0rem;
 							display: block !important;
 						`}
-						onClick={() => setRead([...messagesRead, regionParams?.code])}
+						onClick={() =>
+							dispatch({
+								type: 'SET_LOCALISATION_BANNERS_READ',
+								regions: [...messagesRead, regionParams?.code],
+							})
+						}
 					>
 						<Trans>J'ai compris</Trans>
 					</button>

--- a/source/images/1F3DF.svg
+++ b/source/images/1F3DF.svg
@@ -1,17 +1,231 @@
-<svg id="emoji" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <g id="line">
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M66,33.9998l-4,15H41c0-10.49-2.9-12-5-12s-5,1.51-5,12H10l-4-15c0-4.88,4.23-6.95,9.81-7.78c2.31-2.16,6.51-2.36,10.68-2.08 c2.55-4.75,7.65,0.26,9.51,0.26c1.85,0,7.47-4.98,10.32-0.31c3.9-0.19,7.71,0.11,9.87,2.13C61.77,27.0497,66,29.1198,66,33.9998z"/>
-    <line x1="41" x2="31" y1="48.9998" y2="48.9998" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M58,30.9998c0-2.18-0.68-3.71-1.81-4.78"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M15.81,26.2198c-1.13,1.07-1.81,2.6-1.81,4.78"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M48,33.5698c0-3.54-0.35-6.06-0.94-7.82l-0.74-1.66"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M26.49,24.1398l-0.64,1.61c-0.53,1.76-0.85,4.28-0.85,7.82"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M13,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M19,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M25,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M57,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M51,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M45,48.9998v-6c0-0.55,0.45-1,1-1"/>
-    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M41,48.9998H31c0-10.49,2.9-12,5-12S41,38.5098,41,48.9998z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="emoji"
+   viewBox="0 0 72 72"
+   version="1.1"
+   sodipodi:docname="1F3DF.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs228" />
+  <sodipodi:namedview
+     id="namedview226"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.1808326"
+     inkscape:cx="34.531937"
+     inkscape:cy="31.964962"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="line" />
+  <g
+     id="line"
+     style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1"
+     transform="matrix(1.1156545,0,0,1.1156545,-4.562821,-5.244589)">
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 66,33.9998 -4,15 H 41 c 0,-10.49 -2.9,-12 -5,-12 -2.1,0 -5,1.51 -5,12 H 10 l -4,-15 c 0,-4.88 4.23,-6.95 9.81,-7.78 2.31,-2.16 6.51,-2.36 10.68,-2.08 2.55,-4.75 7.65,0.26 9.51,0.26 1.85,0 7.47,-4.98 10.32,-0.31 3.9,-0.19 7.71,0.11 9.87,2.13 5.58,0.8299 9.81,2.9 9.81,7.78 z"
+       id="path198"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <line
+       x1="41"
+       x2="31"
+       y1="48.999802"
+       y2="48.999802"
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       id="line200"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 58,30.9998 c 0,-2.18 -0.68,-3.71 -1.81,-4.78"
+       id="path202"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 15.81,26.2198 c -1.13,1.07 -1.81,2.6 -1.81,4.78"
+       id="path204"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 48,33.5698 c 0,-3.54 -0.35,-6.06 -0.94,-7.82 l -0.74,-1.66"
+       id="path206"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 26.49,24.1398 -0.64,1.61 c -0.53,1.76 -0.85,4.28 -0.85,7.82"
+       id="path208"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 13,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path210"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 19,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path212"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 25,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path214"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 57,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path216"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 51,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path218"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="m 45,48.9998 v -6 c 0,-0.55 0.45,-1 1,-1"
+       id="path220"
+       style="fill:#e6e6f5;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+    <path
+       fill="none"
+       stroke="#000000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-miterlimit="10"
+       stroke-width="2"
+       d="M 41,48.9998 H 31 c 0,-10.49 2.9,-12 5,-12 2.1,0 5,1.51 5,12 z"
+       id="path222"
+       style="fill:none;fill-opacity:1;stroke:#32337b;stroke-opacity:1" />
+  </g>
+  <g
+     id="g11634"
+     transform="matrix(0.88148905,0,0,0.88148905,-5.265738,5.3000085)"
+     style="stroke:#32337b;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1">
+    <path
+       style="fill:#55acee;fill-opacity:1;stroke:#32337b;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17.964168,11.205141 7.1657008,14.44651 17.734377,18.581497 Z"
+       id="path5000"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#32337b;stroke-width:1.88976;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.140175,21.121566 0.06751,-10.59234"
+       id="path4653"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     id="g11634-5"
+     transform="matrix(1.1776105,0,0,1.1776105,8.9787205,-6.1276747)"
+     style="stroke:#32337b;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1">
+    <path
+       style="fill:#55acee;fill-opacity:1;stroke:#32337b;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17.964168,11.205141 7.1657008,14.44651 17.734377,18.581497 Z"
+       id="path5000-3"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#32337b;stroke-width:1.88976;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.140175,21.121566 0.06751,-10.59234"
+       id="path4653-5"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     id="g11634-5-6"
+     transform="matrix(-1.1776105,0,0,1.1776105,62.68534,-6.3087057)"
+     style="stroke:#32337b;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1">
+    <path
+       style="fill:#55acee;fill-opacity:1;stroke:#32337b;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17.964168,11.205141 7.1657008,14.44651 17.734377,18.581497 Z"
+       id="path5000-3-2"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#32337b;stroke-width:1.88976;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.140175,21.121566 0.06751,-10.59234"
+       id="path4653-5-9"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     id="g11634-3"
+     transform="matrix(-0.90107997,0,0,0.90107997,77.722526,4.7593117)"
+     style="stroke:#32337b;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1">
+    <path
+       style="fill:#55acee;fill-opacity:1;stroke:#32337b;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="M 17.964168,11.205141 7.1657008,14.44651 17.734377,18.581497 Z"
+       id="path5000-6"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#32337b;stroke-width:1.88976;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.140175,21.121566 0.06751,-10.59234"
+       id="path4653-7"
+       sodipodi:nodetypes="cc" />
   </g>
 </svg>

--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -36,8 +36,7 @@ entries:
   Ce guide n'existe pas encore: This guide does not exist yet
   "Cette contribution sera publique : n'y mettez pas d'informations sensibles": 'This contribution will be public: do not put sensitive information in it'
   Cette fiche détaillée n'existe pas encore: This detailed sheet does not exist yet
-  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.: This page allows you to navigate the Nos Gestes Climat paths as if you were
-    one of the typical profiles we have listed.
+  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.: This page allows you to navigate the Nos Gestes Climat paths as if you were one of the typical profiles we have listed.
   Chargement: Loading
   Chargement du modèle de calcul...: Loading the calculation model...
   Chargement...: Loading...
@@ -46,6 +45,7 @@ entries:
   Choisir une autre région: Choose another region
   Choisissez d'abord un nom: Choose a name first
   Choisissez la votre: Choose your own
+  Choisissez la vôtre: Choose yours
   Choisissez une région parmi celles disponibles !: Choose a region among those available!
   Cliquez pour partager le lien: Click to share the link
   Commencer: Start
@@ -66,10 +66,8 @@ entries:
   Courses: Races
   De quoi est faite mon empreinte ?: What is my footprint made of?
   Depuis la page: From the page
-  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.": Behind the nosgestesclimat.fr website, lies the individual climate footprint
-    model of reference consumption.
-  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence..lock": Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat
-    individuelle de consommation de référence.
+  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.": Behind the nosgestesclimat.fr website, lies the individual climate footprint model of reference consumption.
+  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence..lock": Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.
   Diffuser: Broadcast
   Distance: Distance
   Documentation: Documentation
@@ -89,9 +87,7 @@ entries:
   En savoir +: Read more
   En savoir plus: Read more
   'Enlever ': 'Remove '
-  "Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un standard qui évolue régulièrement et qui peut être réutilisé librement par tout type d'acteur.": Entirely open source and contributive, everyone can<1>explore</1> it,
-    <4>give their opinion</4>, <7>improve it</7>. It is a standard that evolves
-    regularly and can be freely reused by any type of actor.
+  "Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un standard qui évolue régulièrement et qui peut être réutilisé librement par tout type d'acteur.": Entirely open source and contributive, everyone can<1>explore</1> it, <4>give their opinion</4>, <7>improve it</7>. It is a standard that evolves regularly and can be freely reused by any type of actor.
   Entre: Between
   Entrez des mots clefs: Enter keywords
   Entrez des mots clefs ici: Enter keywords here
@@ -102,8 +98,7 @@ entries:
   Et mes données ?: What about my data?
   Explorer les catégories: Explore categories
   Explorer notre documentation: Explore our documentation
-  Explorez et modifiez les informations que vous avez saisies dans le parcours nosgestesclimat.: Explore and modify the information you have entered in the nosgestesclimate
-    pathway.
+  Explorez et modifiez les informations que vous avez saisies dans le parcours nosgestesclimat.: Explore and modify the information you have entered in the nosgestesclimate pathway.
   Explorez nos modèles: Explore our models
   Explorez notre documentation: Explore our documentation
   Faire le test: Take the test
@@ -115,6 +110,7 @@ entries:
   Fermer la notification de nouveautés: Close the news notification
   Fermer les options de tri: Close sorting options
   Fréquence: Frequency
+  Groupe: Group
   Guidé: Guided
   Initialisation...: Initialization...
   Insérer cette suggestion: Insert this suggestion
@@ -127,17 +123,11 @@ entries:
   La voiture en chiffres: The car in figures
   Label: Label
   Label (facultatif): Label (optional)
-  "Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": The model now includes <1>{numberOfRules}</1> calculation rules. Among them,
-    {numberOfQuestions} rules are questions to be asked to the user to calculate
-    a specific result.
-  "Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": The model now includes {numberOfRules} calculation rules. Among them,
-    {numberOfQuestions} rules are questions to be asked to the user to calculate
-    a specific result.
+  "Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": The model now includes <1>{numberOfRules}</1> calculation rules. Among them, {numberOfQuestions} rules are questions to be asked to the user to calculate a specific result.
+  "Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": The model now includes {numberOfRules} calculation rules. Among them, {numberOfQuestions} rules are questions to be asked to the user to calculate a specific result.
   Le modèle d'empreinte carbone de référence: The reference carbon footprint model
   'Le reste : ': 'The rest '
-  "Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.": The Nos Gestes Climat simulator is based on the calculation model of the
-    same name, composed of a set of bricks. On this documentation, you have
-    transparent access to all the variables of the calculation.
+  "Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.": The Nos Gestes Climat simulator is based on the calculation model of the same name, composed of a set of bricks. On this documentation, you have transparent access to all the variables of the calculation.
   Le test: The test
   Le titre bref de votre problème: The short title of your problem
   'Les 3 actions au plus fort impact pour vous :': 'The 3 actions with the highest impact for you:'
@@ -200,6 +190,7 @@ entries:
   Pour aller plus loin: To go further
   'Pour en savoir plus, tout est expliqué dans ': 'To learn more, everything is explained in '
   Problème de traduction: Translation problem
+  Profil: Profile
   Progression dans les diapo: Progression through the slides
   Précédent: Previous
   Prêt à démarrer ?: Ready to get started?
@@ -272,102 +263,38 @@ entries:
   cette page: this page
   components.NewsBanner.miseAJourDate: Last update {{date}}
   components.NewsBanner.miseAJourDate.lock: Dernière mise à jour {{date}}
-  components.ScoreExplanation.text.p1: 🧮 This is your starting score, calculated
-    from pre-assigned answers to each question! It will change with each new
-    answer.
-  components.ScoreExplanation.text.p1.lock: 🧮 Voici votre score de départ,
-    calculé à partir de réponses attribuées à l'avance à chaque question ! Il
-    évoluera à chaque nouvelle réponse.
+  components.ScoreExplanation.text.p1: 🧮 This is your starting score, calculated from pre-assigned answers to each question! It will change with each new answer.
+  components.ScoreExplanation.text.p1.lock: 🧮 Voici votre score de départ, calculé à partir de réponses attribuées à l'avance à chaque question ! Il évoluera à chaque nouvelle réponse.
   components.ScoreExplanation.text.p2: 🧮 Here is your provisional score, it changes with each new answer!
   components.ScoreExplanation.text.p2.lock: 🧮 Voici votre score provisoire, il évolue à chaque nouvelle réponse !
-  components.ScoreExplanation.text.p3: '🤔 If you answer "I don''t know" to a
-    question, the score will not change: you are assigned a default value.'
-  components.ScoreExplanation.text.p3.lock: '🤔 Si vous répondez "je ne sais pas"
-    à une question, le score ne changera pas : une valeur par défaut vous est
-    attribuée.'
+  components.ScoreExplanation.text.p3: '🤔 If you answer "I don''t know" to a question, the score will not change: you are assigned a default value.'
+  components.ScoreExplanation.text.p3.lock: '🤔 Si vous répondez "je ne sais pas" à une question, le score ne changera pas : une valeur par défaut vous est attribuée.'
   components.ScoreExplanation.text.p4: 💡 We improve the calculation and its default valuesevery<1>month</1>!
   components.ScoreExplanation.text.p4.lock: 💡 Nous améliorons le calcul et ses valeurs par défaut<1>tous les mois</1>!
-  components.TranslationAlertBanner.wikiLink: The translation of this page is in
-    <1>beta</1> version. <4>A problem, a suggestion?</4>
-  components.TranslationAlertBanner.wikiLink.lock: La traduction de cette page est
-    en version <1>beta</1>. <4>Un problème, une suggestion ?</4>
-  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne: You travel {{kmParcouru}} km avec en moyenne {{nbPersonnes}} people in the
-    car.
-  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne.lock: Vous parcourez {{kmParcouru}} km avec en moyenne {{nbPersonnes}} personnes
-    dans la voiture.
+  components.TranslationAlertBanner.wikiLink: The translation of this page is in <1>beta</1> version. <4>A problem, a suggestion?</4>
+  components.TranslationAlertBanner.wikiLink.lock: La traduction de cette page est en version <1>beta</1>. <4>Un problème, une suggestion ?</4>
+  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne: You travel {{kmParcouru}} km avec en moyenne {{nbPersonnes}} people in the car.
+  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne.lock: Vous parcourez {{kmParcouru}} km avec en moyenne {{nbPersonnes}} personnes dans la voiture.
   components.conversation.select.NumberedMosaic.choixAFaire: ' You still have {{nbChoix}} to choose from.'
   components.conversation.select.NumberedMosaic.choixAFaire.lock: ' Il vous reste {{nbChoix}} choix à faire.'
   components.conversation.select.NumberedMosaic.choixEnTrop: You have made {{nbChoix}} too many choices!
   components.conversation.select.NumberedMosaic.choixEnTrop.lock: Vous avez fait {{nbChoix}} choix en trop !
-  components.localisation.Localisation.warnMessage: For the moment, there is no
-    calculation model for {{countryName}}, the French model is proposed by
-    default.
-  components.localisation.Localisation.warnMessage.lock: Pour le moment, il
-    n'existe pas de modèle de calcul pour {{countryName}}, le modèle Français
-    vous est proposé par défaut.
-  components.localisation.Localisation.warnMessage2: We could not detect your
-    country of simulation, the French model is proposed by default.
-  components.localisation.Localisation.warnMessage2.lock: Nous n'avons pas pu
-    détecter votre pays de simulation, le modèle Français vous est proposé par
-    défaut.
+  components.localisation.Localisation.warnMessage: For the moment, there is no calculation model for {{countryName}}, the French model is proposed by default.
+  components.localisation.Localisation.warnMessage.lock: Pour le moment, il n'existe pas de modèle de calcul pour {{countryName}}, le modèle Français vous est proposé par défaut.
+  components.localisation.Localisation.warnMessage2: We could not detect your country of simulation, the French model is proposed by default.
+  components.localisation.Localisation.warnMessage2.lock: Nous n'avons pas pu détecter votre pays de simulation, le modèle Français vous est proposé par défaut.
   components.localisation.LocalisationMessage.betaMsg: It is currently in <1>beta</1> version.
   components.localisation.LocalisationMessage.betaMsg.lock: Elle est actuellement en version <1>bêta</1>.
   components.localisation.LocalisationMessage.version: You are using the <1>{{versionName}}</1> version of the test.
   components.localisation.LocalisationMessage.version.lock: Vous utilisez la version <1>{{versionName}}</1> du test.
   components.localisation.LocalisationMessage.warnMessage: Your region is not yet supported, the French model is proposed by default.
-  components.localisation.LocalisationMessage.warnMessage.lock: Votre région n'est pas encore supportée, le modèle Français vous est proposé
-    par défaut.
-  components.stats.StatsContent.dureeDesVisites: <0>Learn more about this
-    site</0><1>This section is generated from visits over the last 60 days.
-    Visits with a time spent on the site of less than 1 minute have been
-    discarded. To avoid the iframe bias that can generate inactive visitors in
-    the statistics, the average time on the site has been calculated from active
-    visits (the user has clicked on "Take the test").</1>
-  components.stats.StatsContent.dureeDesVisites.lock: <0>En savoir
-    plus</0><1>Cette section est générée à partir des visites des 60 derniers
-    jours. Les visites dont le temps passé sur le site est inférieur à 1 minute
-    ont été écartées. Pour éviter le biais de l'iframe qui peut générer des
-    visiteurs inactifs dans les statistiques, le temps moyen sur le site a été
-    calculé à partir des visites actives (l'utilisateur a cliqué sur "Faire le
-    test").</1>
-  components.stats.StatsContent.integrationEtIframes: <0>Learn more about iframe
-    integrations</0><1>Iframe integrations are detected via the 'iframe'
-    parameter in the URL, only if the integrator has used the <2>dedicated
-    script</2>. Thus, the visits via iframes of integrators who did not use this
-    script are scattered in the general visits of Nos Gestes Climat. Pending
-    more precise figures, this rate is therefore potentially underestimated
-    compared to reality. <5>(Data valid for the last 30 days)</5></1>
-  components.stats.StatsContent.integrationEtIframes.lock: <0>En savoir
-    plus</0><1>Les intégrations en iframe sont détéctées via le paramètre
-    'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé le <2>script
-    dédié</2>. Ainsi, les visites via les iframes d'intégrateurs qui n'ont pas
-    utilisé ce script sont dispersées dans les visites générales de Nos Gestes
-    Climat. Dans l'attente de chiffres plus précis, ce taux est donc
-    potentiellement sous-estimé par rapport à la réalité. <5>(Données valables
-    pour les 30 derniers jours)</5></1>
-  components.stats.StatsContent.scoreUtilisateurs: '<0>Read more about it</0><1>Of
-    course, we do not collect <2>user data</2>. Nevertheless, the total score as
-    well as the footprint per category is present in the end of test URL. In
-    this section, we aggregate this information to get an idea of the average
-    carbon footprint of our users and the distribution of the score in order to
-    analyze these results in the context of the evolutions of the model.</1>
-    <3>The objective here is not to evaluate the carbon footprint of the French:
-    a priori, the test users are not representative of the French. Moreover,
-    these data can be biased by users who would come back several times on the
-    end page, changing their answers to the test (which creates new end
-    url).</3>'
-  components.stats.StatsContent.scoreUtilisateurs.lock: "<0>En savoir
-    plus</0><1>Bien sûr, nous ne collectons pas <2>les données utlisateurs</2>.
-    Néanmoins, le score total ainsi que l'empreinte par catégorie est présente
-    dans l'URL de fin de test. Dans cette section, nous agrégeons cees
-    informations pour avoir une idée de l'empreinte carbone moyenne de nos
-    utilisateurs et de distribution du score afin d'analyser ces résultats dans
-    le contexte des évolutions du modèle.</1> <3>L'objectif ici n'est pas
-    d'évaluer l'empreinte carbone des Français : à priori, les utilisateurs du
-    tests de sont pas représentatifs des Français. De plus, ces données peuvent
-    être biaisées par des utilisateurs qui reviendraient à plusieurs reprises
-    sur la page de fin, en changeant ses réponses au test (ce qui crée de
-    nouveaux url de fin).</3>"
+  components.localisation.LocalisationMessage.warnMessage.lock: Votre région n'est pas encore supportée, le modèle Français vous est proposé par défaut.
+  components.stats.StatsContent.dureeDesVisites: <0>Learn more about this site</0><1>This section is generated from visits over the last 60 days. Visits with a time spent on the site of less than 1 minute have been discarded. To avoid the iframe bias that can generate inactive visitors in the statistics, the average time on the site has been calculated from active visits (the user has clicked on "Take the test").</1>
+  components.stats.StatsContent.dureeDesVisites.lock: <0>En savoir plus</0><1>Cette section est générée à partir des visites des 60 derniers jours. Les visites dont le temps passé sur le site est inférieur à 1 minute ont été écartées. Pour éviter le biais de l'iframe qui peut générer des visiteurs inactifs dans les statistiques, le temps moyen sur le site a été calculé à partir des visites actives (l'utilisateur a cliqué sur "Faire le test").</1>
+  components.stats.StatsContent.integrationEtIframes: <0>Learn more about iframe integrations</0><1>Iframe integrations are detected via the 'iframe' parameter in the URL, only if the integrator has used the <2>dedicated script</2>. Thus, the visits via iframes of integrators who did not use this script are scattered in the general visits of Nos Gestes Climat. Pending more precise figures, this rate is therefore potentially underestimated compared to reality. <5>(Data valid for the last 30 days)</5></1>
+  components.stats.StatsContent.integrationEtIframes.lock: <0>En savoir plus</0><1>Les intégrations en iframe sont détéctées via le paramètre 'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé le <2>script dédié</2>. Ainsi, les visites via les iframes d'intégrateurs qui n'ont pas utilisé ce script sont dispersées dans les visites générales de Nos Gestes Climat. Dans l'attente de chiffres plus précis, ce taux est donc potentiellement sous-estimé par rapport à la réalité. <5>(Données valables pour les 30 derniers jours)</5></1>
+  components.stats.StatsContent.scoreUtilisateurs: '<0>Read more about it</0><1>Of course, we do not collect <2>user data</2>. Nevertheless, the total score as well as the footprint per category is present in the end of test URL. In this section, we aggregate this information to get an idea of the average carbon footprint of our users and the distribution of the score in order to analyze these results in the context of the evolutions of the model.</1> <3>The objective here is not to evaluate the carbon footprint of the French: a priori, the test users are not representative of the French. Moreover, these data can be biased by users who would come back several times on the end page, changing their answers to the test (which creates new end url).</3>'
+  components.stats.StatsContent.scoreUtilisateurs.lock: "<0>En savoir plus</0><1>Bien sûr, nous ne collectons pas <2>les données utlisateurs</2>. Néanmoins, le score total ainsi que l'empreinte par catégorie est présente dans l'URL de fin de test. Dans cette section, nous agrégeons cees informations pour avoir une idée de l'empreinte carbone moyenne de nos utilisateurs et de distribution du score afin d'analyser ces résultats dans le contexte des évolutions du modèle.</1> <3>L'objectif ici n'est pas d'évaluer l'empreinte carbone des Français : à priori, les utilisateurs du tests de sont pas représentatifs des Français. De plus, ces données peuvent être biaisées par des utilisateurs qui reviendraient à plusieurs reprises sur la page de fin, en changeant ses réponses au test (ce qui crée de nouveaux url de fin).</3>"
   de CO₂e en moyenne: of CO₂e on average
   de visites ce mois ci<1>&nbsp;(par rapport au mois d'avant)</1>: of visits this month<1> (compared to the month before)</1>
   derniers: latest
@@ -378,20 +305,14 @@ entries:
   en moyenne sur le site: on average on the site
   et: and
   et visualisez les résultats du groupe: and view the results of the group
-  feedback.bad.form.headline: Your feedback is valuable to us in order to
-    continuously improve this site. What should we work on to better meet your
-    expectations?
-  feedback.bad.form.headline.lock: Votre retour nous est précieux afin d'améliorer
-    ce site en continu. Sur quoi devrions nous travailler afin de mieux répondre
-    à vos attentes ?
+  feedback.bad.form.headline: Your feedback is valuable to us in order to continuously improve this site. What should we work on to better meet your expectations?
+  feedback.bad.form.headline.lock: Votre retour nous est précieux afin d'améliorer ce site en continu. Sur quoi devrions nous travailler afin de mieux répondre à vos attentes ?
   feedback.question: Is this page useful to you?
   feedback.question.lock: Cette page vous est utile ?
   feedback.reportError: Make a suggestion
   feedback.reportError.lock: Faire une suggestion
-  feedback.thanks: Thank you for your feedback! You can contact us directly at
-    <2>contact@mon-entreprise.beta.gouv.fr</2>
-  feedback.thanks.lock: Merci pour votre retour ! Vous pouvez nous contacter
-    directement à <2>contact@mon-entreprise.beta.gouv.fr</2>
+  feedback.thanks: Thank you for your feedback! You can contact us directly at <2>contact@mon-entreprise.beta.gouv.fr</2>
+  feedback.thanks.lock: Merci pour votre retour ! Vous pouvez nous contacter directement à <2>contact@mon-entreprise.beta.gouv.fr</2>
   fois par: times per
   habitant: resident
   habitants: inhabitants
@@ -404,168 +325,69 @@ entries:
   le - d'impact climat: the - climate impact
   meta.pages.actions.description: Find out how you can reduce your climate footprint
   meta.pages.actions.description.lock: Découvrez les gestes qui veous permettent de réduire votre empreinte climat
-  meta.publicodes.About.description: This simulator allows you to evaluate your
-    total annual individual carbon footprint and by major categories (food,
-    transportation, housing, miscellaneous, utilities, digital), to situate it
-    in relation to the climate objectives and above all to take action at your
-    level with personalized gestures according to your answers.
-  meta.publicodes.About.description.lock: Ce simulateur vous permet d'évaluer
-    votre empreinte carbone individuelle annuelle totale et par grandes
-    catégories (alimentation, transport, logement, divers, services publics,
-    numérique), de la situer par rapport aux objectifs climatiques et surtout de
-    passer à l’action à votre niveau avec des gestes personnalisés en fonction
-    de vos réponses.
+  meta.publicodes.About.description: This simulator allows you to evaluate your total annual individual carbon footprint and by major categories (food, transportation, housing, miscellaneous, utilities, digital), to situate it in relation to the climate objectives and above all to take action at your level with personalized gestures according to your answers.
+  meta.publicodes.About.description.lock: Ce simulateur vous permet d'évaluer votre empreinte carbone individuelle annuelle totale et par grandes catégories (alimentation, transport, logement, divers, services publics, numérique), de la situer par rapport aux objectifs climatiques et surtout de passer à l’action à votre niveau avec des gestes personnalisés en fonction de vos réponses.
   meta.publicodes.About.title: About us
   meta.publicodes.About.title.lock: À propos
-  meta.publicodes.Accessibility.description: The site Nos Gestes Climat is
-    partially compliant with the General Accessibility Guidelines, RGAA version
-    4.1
-  meta.publicodes.Accessibility.description.lock: Le site Nos Gestes Climat est
-    partiellement conforme avec le référentiel général d’amélioration de
-    l’accessibilité, RGAA version 4.1
+  meta.publicodes.Accessibility.description: The site Nos Gestes Climat is partially compliant with the General Accessibility Guidelines, RGAA version 4.1
+  meta.publicodes.Accessibility.description.lock: Le site Nos Gestes Climat est partiellement conforme avec le référentiel général d’amélioration de l’accessibilité, RGAA version 4.1
   meta.publicodes.Accessibility.title: Accessibility
   meta.publicodes.Accessibility.title.lock: Accessibilité
-  meta.publicodes.CGU.description: These general terms of use (called "GTC") set
-    the legal framework of the Platform "Nos Gestes Climat" and define the
-    conditions of access and use of services by the User.
-  meta.publicodes.CGU.description.lock: Les présentes conditions générales
-    d'utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme
-    "Nos Gestes Climat" et définissent les conditions d'accès et d'utilisation
-    des services par l'Utilisateur.
+  meta.publicodes.CGU.description: These general terms of use (called "GTC") set the legal framework of the Platform "Nos Gestes Climat" and define the conditions of access and use of services by the User.
+  meta.publicodes.CGU.description.lock: Les présentes conditions générales d'utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme "Nos Gestes Climat" et définissent les conditions d'accès et d'utilisation des services par l'Utilisateur.
   meta.publicodes.CGU.title: Terms and conditions of use
   meta.publicodes.CGU.title.lock: Conditions générales d'utilisation
-  meta.publicodes.Contribution.description: Find out the most common questions
-    about Our Climate Action, and how to ask new ones or help us.
-  meta.publicodes.Contribution.description.lock: Découvrez les questions
-    fréquentes sur Nos Gestes Climat, et comment en poser de nouvelles ou nous
-    aider.
-  meta.publicodes.Diffuser.description: This simulator allows you to evaluate your
-    total annual individual carbon footprint and by major categories (food,
-    transportation, housing, miscellaneous, utilities, digital), to situate it
-    in relation to the climate objectives and above all to take action at your
-    level with personalized gestures according to your answers.
-  meta.publicodes.Diffuser.description.lock: Ce simulateur vous permet d'évaluer
-    votre empreinte carbone individuelle annuelle totale et par grandes
-    catégories (alimentation, transport, logement, divers, services publics,
-    numérique), de la situer par rapport aux objectifs climatiques et surtout de
-    passer à l’action à votre niveau avec des gestes personnalisés en fonction
-    de vos réponses.
+  meta.publicodes.Contribution.description: Find out the most common questions about Our Climate Action, and how to ask new ones or help us.
+  meta.publicodes.Contribution.description.lock: Découvrez les questions fréquentes sur Nos Gestes Climat, et comment en poser de nouvelles ou nous aider.
+  meta.publicodes.Diffuser.description: This simulator allows you to evaluate your total annual individual carbon footprint and by major categories (food, transportation, housing, miscellaneous, utilities, digital), to situate it in relation to the climate objectives and above all to take action at your level with personalized gestures according to your answers.
+  meta.publicodes.Diffuser.description.lock: Ce simulateur vous permet d'évaluer votre empreinte carbone individuelle annuelle totale et par grandes catégories (alimentation, transport, logement, divers, services publics, numérique), de la situer par rapport aux objectifs climatiques et surtout de passer à l’action à votre niveau avec des gestes personnalisés en fonction de vos réponses.
   meta.publicodes.Diffuser.title: Sharing Nos Gestes Climat
   meta.publicodes.Diffuser.title.lock: Diffuser Nos Gestes Climat
-  meta.publicodes.Landing.description: Test your carbon footprint, alone or in a
-    group. Discover the breakdown of your footprint. Follow the path to action
-    to reduce it.
-  meta.publicodes.Landing.description.lock: Testez votre empreinte carbone, tout
-    seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez le
-    parcours de passage à l'action pour la réduire.
-  meta.publicodes.LandingExplanations.description: Test your carbon footprint,
-    alone or in a group. Discover the breakdown of your footprint. Follow the
-    path to action to reduce it.
-  meta.publicodes.LandingExplanations.description.lock: Testez votre empreinte
-    carbone, tout seul ou en groupe. Découvrez la répartition de votre
-    empreinte. Suivez le parcours de passage à l'action pour la réduire.
-  meta.publicodes.Méthode.description: Our calculation model is completely
-    transparent. Everyone can explore it, give their opinion, improve it.
-  meta.publicodes.Méthode.description.lock: Notre modèle de calcul est entièrement
-    transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
+  meta.publicodes.Landing.description: Test your carbon footprint, alone or in a group. Discover the breakdown of your footprint. Follow the path to action to reduce it.
+  meta.publicodes.Landing.description.lock: Testez votre empreinte carbone, tout seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez le parcours de passage à l'action pour la réduire.
+  meta.publicodes.LandingExplanations.description: Test your carbon footprint, alone or in a group. Discover the breakdown of your footprint. Follow the path to action to reduce it.
+  meta.publicodes.LandingExplanations.description.lock: Testez votre empreinte carbone, tout seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez le parcours de passage à l'action pour la réduire.
+  meta.publicodes.Méthode.description: Our calculation model is completely transparent. Everyone can explore it, give their opinion, improve it.
+  meta.publicodes.Méthode.description.lock: Notre modèle de calcul est entièrement transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
   meta.publicodes.Méthode.title: Understanding our calculations
   meta.publicodes.Méthode.title.lock: Comprendre nos calculs
-  meta.publicodes.PetrogazLanding.description: Nos Gestes Climat allows you to
-    estimate not only your climate footprint, but also your oil consumption. Oil
-    is responsible for a large part of the climate footprint, but its purchase
-    also has other consequences, notably geopolitical.
-  meta.publicodes.PetrogazLanding.description.lock: Nos Gestes Climat vous permet
-    non seulement d'estimer votre empreinte sur le climat, mais également votre
-    consommation de pétrole. Ce dernier est responsable d'une grande partie de
-    l'empreinte climat, mais son achat a également d'autres conséquences,
-    notamment géopolitiques.
+  meta.publicodes.PetrogazLanding.description: Nos Gestes Climat allows you to estimate not only your climate footprint, but also your oil consumption. Oil is responsible for a large part of the climate footprint, but its purchase also has other consequences, notably geopolitical.
+  meta.publicodes.PetrogazLanding.description.lock: Nos Gestes Climat vous permet non seulement d'estimer votre empreinte sur le climat, mais également votre consommation de pétrole. Ce dernier est responsable d'une grande partie de l'empreinte climat, mais son achat a également d'autres conséquences, notamment géopolitiques.
   meta.publicodes.PetrogazLanding.title: My oil and gas footprint
   meta.publicodes.PetrogazLanding.title.lock: Mon empreinte pétrole et gaz
-  meta.publicodes.Privacy.description: Nos Gestes Climat, out of group mode, work
-    without a server, so your data stays with you. We collect anonymously
-    aggregated data to improve the simulator.
-  meta.publicodes.Privacy.description.lock: Nos gestes climat, hors mode groupe,
-    fonctionne sans serveur, donc vos données restent chez vous. Nous collectons
-    anonymement des données aggregées pour améliorer le simulateur.
+  meta.publicodes.Privacy.description: Nos Gestes Climat, out of group mode, work without a server, so your data stays with you. We collect anonymously aggregated data to improve the simulator.
+  meta.publicodes.Privacy.description.lock: Nos gestes climat, hors mode groupe, fonctionne sans serveur, donc vos données restent chez vous. Nous collectons anonymement des données aggregées pour améliorer le simulateur.
   meta.publicodes.Privacy.title: Personal data
   meta.publicodes.Privacy.title.lock: Données personnelles
   meta.publicodes.fin.Budget.description: My climate footprint is {{roundedValue}} tonnes of CO2e. Measure yours!
-  meta.publicodes.fin.Budget.description.lock: Mon empreinte climat est de
-    {{roundedValue}} tonnes de CO2e. Mesure la tienne !
+  meta.publicodes.fin.Budget.description.lock: Mon empreinte climat est de {{roundedValue}} tonnes de CO2e. Mesure la tienne !
   meta.publicodes.fin.Petrogaz.description: My oil footprint is {{empreinte}} full of oil. Measure yours!
-  meta.publicodes.fin.Petrogaz.description.lock: Mon empreinte pétrole est de
-    {{empreinte}} pleins de pétrole. Mesure la tienne !
-  meta.publicodes.fin.actionslide.description: Top 3 actions to reduce my climate
-    footprint by {{roundedValue}} tonnes of CO₂‍ₑ.
-  meta.publicodes.fin.actionslide.description.lock: Le top 3 des actions pour
-    réduire mon empreinte climat de {{roundedValue}} tonnes de CO₂ₑ.
-  meta.publicodes.pages.Documentation.description: Our calculation model is
-    completely transparent. Everyone can explore it, give their opinion, improve
-    it.
-  meta.publicodes.pages.Documentation.description.lock: Notre modèle de calcul est
-    entièrement transparent. Chacun peut l'explorer, donner son avis,
-    l'améliorer.
-  meta.publicodes.pages.Documentation.intro: The Nos Gestes Climat simulator is
-    based on the calculation model of the same name, composed of a set of
-    bricks. On this documentation, you have transparent access to all the
-    variables of the calculation.
-  meta.publicodes.pages.Documentation.intro.lock: Le simulateur Nos Gestes Climat
-    est basé sur le modèle de calcul du même nom, composé d'un ensemble de
-    briques. Sur cette documentation, vous avez accès en toute transparence à
-    l'ensemble des variables du calcul.
+  meta.publicodes.fin.Petrogaz.description.lock: Mon empreinte pétrole est de {{empreinte}} pleins de pétrole. Mesure la tienne !
+  meta.publicodes.fin.actionslide.description: Top 3 actions to reduce my climate footprint by {{roundedValue}} tonnes of CO₂‍ₑ.
+  meta.publicodes.fin.actionslide.description.lock: Le top 3 des actions pour réduire mon empreinte climat de {{roundedValue}} tonnes de CO₂ₑ.
+  meta.publicodes.pages.Documentation.description: Our calculation model is completely transparent. Everyone can explore it, give their opinion, improve it.
+  meta.publicodes.pages.Documentation.description.lock: Notre modèle de calcul est entièrement transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
+  meta.publicodes.pages.Documentation.intro: The Nos Gestes Climat simulator is based on the calculation model of the same name, composed of a set of bricks. On this documentation, you have transparent access to all the variables of the calculation.
+  meta.publicodes.pages.Documentation.intro.lock: Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.
   minutes: minutes
-  model.active: Here are some examples of important <1>issues</1> of the moment
-    among the hundred or so documented topics.
-  model.active.lock: Voici à titre d'exemple quelques <1>issues</1> importantes du
-    moment parmi la centaine de sujets documentés.
-  model.intro: Behind the nosgestesclimat.fr website, lies the individual climate
-    footprint model of reference consumption.
-  model.intro.lock: Derrière le site nosgestesclimat.fr, se cache le modèle
-    d'empreinte climat individuelle de consommation de référence.
-  model.intro2: Entirely open source and contributive, everyone can<1>explore</1>
-    it, <4>give their opinion</4>, <7>improve it</7>.
-  model.intro2.lock: Entièrement ouvert (open source) et contributif, chacun peut
-    l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>.
-  model.modern: The model is based on <1>publicodes</1>, a language designed by
-    the state to express public interest algorithms.
-  model.modern.lock: Le modèle est basé sur <1>publicodes</1>, un langage conçu
-    par l'État pour exprimer des algorithmes d'intérêt public.
-  model.modern2: Fully customizable, from the questions asked to the user to the
-    assumptions of the calculation model, it can be <2>freely</2> reused by any
-    type of actor.
-  model.modern2.lock: Entièrement paramétrable, depuis les questions posées à
-    l'utilisateur jusqu'aux hypothèses du modèle de calcul, il peut être
-    réutilisé <2>librement</2> par tout type d'acteur.
-  model.modern3: ⬇️ Below, you can see the influence of 3 calculation parameters
-    on the final results.
-  model.modern3.lock: ⬇️ Ci-dessous, vous pouvez voir l'influence de 3 paramètres
-    de calcul sur les résultats finaux.
-  model.modern4: The calculation model is embedded directly in the client, the
-    calculation takes place there in your browser, not on our servers. The data
-    collected is so descriptive of users' lives, and therefore sensitive in
-    terms of privacy, that doing the calculations on the server side <2>and
-    storing them</2> would pose too high a risk.
-  model.modern4.lock: Le modèle de calcul est directement embarqué chez le client,
-    le calcul a lieu là dans votre navigateur, pas sur nos serveurs. Les données
-    collectées sont si descriptives de la vie des utilisateurs, donc sensibles
-    en termes de vie privée, que faire les calculs côté serveur <2>et les
-    stocker</2> poserait un risque trop élevé.
-  model.stats: The model now includes <1></1> calculation rules. Among them,
-    <3></3> rules are questions to ask the user to calculate a precise result.
-  model.stats.lock: Le modèle comprend aujourd'hui <1></1> règles de calcul. Parmi
-    elles, <3></3> règles sont des questions à poser à l'utilisateur pour
-    calculer un résultat précis.
-  model.stats2: It consists of a combination of hundreds of "bottom-up" micro
-    models for the carbon consumption of our daily lives, and a "top-down" model
-    derived from the work of the SDES to estimate the per capita footprint of
-    so-called societal services (public services and basic services such as
-    telecommunications). <2>Learn more about this hybridization</2>.
-  model.stats2.lock: Il est constitué d'une combinaison de centaines de modèles
-    micro "bottom-up" pour les consommations carbonées de notre vie quotidienne,
-    et d'un modèle "top-down" dérivé des travaux du SDES pour estimer
-    l'empreinte par personne des services dits sociétaux (services publics et
-    services de base tels les télécom). <2>En savoir plus sur cette
-    hybridation</2>.
+  model.active: Here are some examples of important <1>issues</1> of the moment among the hundred or so documented topics.
+  model.active.lock: Voici à titre d'exemple quelques <1>issues</1> importantes du moment parmi la centaine de sujets documentés.
+  model.intro: Behind the nosgestesclimat.fr website, lies the individual climate footprint model of reference consumption.
+  model.intro.lock: Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.
+  model.intro2: Entirely open source and contributive, everyone can<1>explore</1> it, <4>give their opinion</4>, <7>improve it</7>.
+  model.intro2.lock: Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>.
+  model.modern: The model is based on <1>publicodes</1>, a language designed by the state to express public interest algorithms.
+  model.modern.lock: Le modèle est basé sur <1>publicodes</1>, un langage conçu par l'État pour exprimer des algorithmes d'intérêt public.
+  model.modern2: Fully customizable, from the questions asked to the user to the assumptions of the calculation model, it can be <2>freely</2> reused by any type of actor.
+  model.modern2.lock: Entièrement paramétrable, depuis les questions posées à l'utilisateur jusqu'aux hypothèses du modèle de calcul, il peut être réutilisé <2>librement</2> par tout type d'acteur.
+  model.modern3: ⬇️ Below, you can see the influence of 3 calculation parameters on the final results.
+  model.modern3.lock: ⬇️ Ci-dessous, vous pouvez voir l'influence de 3 paramètres de calcul sur les résultats finaux.
+  model.modern4: The calculation model is embedded directly in the client, the calculation takes place there in your browser, not on our servers. The data collected is so descriptive of users' lives, and therefore sensitive in terms of privacy, that doing the calculations on the server side <2>and storing them</2> would pose too high a risk.
+  model.modern4.lock: Le modèle de calcul est directement embarqué chez le client, le calcul a lieu là dans votre navigateur, pas sur nos serveurs. Les données collectées sont si descriptives de la vie des utilisateurs, donc sensibles en termes de vie privée, que faire les calculs côté serveur <2>et les stocker</2> poserait un risque trop élevé.
+  model.stats: The model now includes <1></1> calculation rules. Among them, <3></3> rules are questions to ask the user to calculate a precise result.
+  model.stats.lock: Le modèle comprend aujourd'hui <1></1> règles de calcul. Parmi elles, <3></3> règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.
+  model.stats2: It consists of a combination of hundreds of "bottom-up" micro models for the carbon consumption of our daily lives, and a "top-down" model derived from the work of the SDES to estimate the per capita footprint of so-called societal services (public services and basic services such as telecommunications). <2>Learn more about this hybridization</2>.
+  model.stats2.lock: Il est constitué d'une combinaison de centaines de modèles micro "bottom-up" pour les consommations carbonées de notre vie quotidienne, et d'un modèle "top-down" dérivé des travaux du SDES pour estimer l'empreinte par personne des services dits sociétaux (services publics et services de base tels les télécom). <2>En savoir plus sur cette hybridation</2>.
   mois: month
   mon empreinte annuelle: my annual footprint
   mon objectif: my goal
@@ -575,10 +397,8 @@ entries:
   ou: or
   pages.News.determinant: of
   pages.News.determinant.lock: of
-  pages.News.premierParagraphe: We are continuously improving the site based on
-    your feedback. Discover here the latest news.
-  pages.News.premierParagraphe.lock: Nous améliorons le site en continu à partir
-    de vos retours. Découvrez ici les dernières nouveautés.
+  pages.News.premierParagraphe: We are continuously improving the site based on your feedback. Discover here the latest news.
+  pages.News.premierParagraphe.lock: Nous améliorons le site en continu à partir de vos retours. Découvrez ici les dernières nouveautés.
   participant: participant
   pleins: full tanks
   pleins de pétrole: full tanks of oil
@@ -589,31 +409,20 @@ entries:
   plus de 100 kg: over 100 kg
   publicodes.ActionTutorial.félicitation: You have completed your simulation, 👏 well done!
   publicodes.ActionTutorial.félicitation.lock: Vous avez terminé votre simulation, 👏 bravo !
-  publicodes.ActionTutorial.msgEstimation: You now know your footprint, estimated
-    at {{value}} {{unit}}, and you probably already have ideas to reduce it...
-  publicodes.ActionTutorial.msgEstimation.lock: Vous connaissez maintenant votre
-    empreinte, estimée à {{value}} {{unit}}, et vous avez sûrement déjà des
-    idées pour la réduire...
+  publicodes.ActionTutorial.msgEstimation: You now know your footprint, estimated at {{value}} {{unit}}, and you probably already have ideas to reduce it...
+  publicodes.ActionTutorial.msgEstimation.lock: Vous connaissez maintenant votre empreinte, estimée à {{value}} {{unit}}, et vous avez sûrement déjà des idées pour la réduire...
   publicodes.ActionTutorial.msgPrécision: 💡 To improve accuracy, some actions will ask you a few more questions.
-  publicodes.ActionTutorial.msgPrécision.lock: 💡 Pour améliorer la précision,
-    certaines actions vous poseront quelques questions en plus.
+  publicodes.ActionTutorial.msgPrécision.lock: 💡 Pour améliorer la précision, certaines actions vous poseront quelques questions en plus.
   publicodes.ActionTutorial.msgPrésentation: 'To help you, we will present you with <2>a list of actions</2>:'
   publicodes.ActionTutorial.msgPrésentation.lock: "Pour vous aider, nous vous présenterons <2>une liste d'actions</2> :"
   publicodes.ActionVignette.questionsRestantesText: '{{nbRemainingQuestions}} remaining question{{pluralSuffix}}'
   publicodes.ActionVignette.questionsRestantesText.lock: '{{nbRemainingQuestions}} question{{pluralSuffix}} restante{{pluralSuffix}}'
   publicodes.ActionsOptionsBar.actionsRecap: '{{numberOfAvailableFinalActions}} actions available,'
   publicodes.ActionsOptionsBar.actionsRecap.lock: '{{numberOfAvailableFinalActions}} actions disponibles,'
-  publicodes.AllActions.allerPlusLoin: <0>Going further</0><1><0>Beyond a simple
-    figure, discover the stakes behind each action.</0></1>
-  publicodes.AllActions.allerPlusLoin.lock: <0>Aller plus loin</0><1><0>Au-delà
-    d'un simple chiffre, découvrez les enjeux qui se cachent derrière chaque
-    action.</0></1>
-  publicodes.AllActions.msgPlusActions: <0>We don't have any more high-impact
-    quantified actions to offer you 🤷</0><1>Discover below some tracks to act
-    differently ⏬</1>
-  publicodes.AllActions.msgPlusActions.lock: <0>Nous n'avons plus d'actions
-    chiffrées très impactantes à vous proposer 🤷</0><1>Découvrez plus bas
-    quelques pistes pour agir autrement ⏬</1>
+  publicodes.AllActions.allerPlusLoin: <0>Going further</0><1><0>Beyond a simple figure, discover the stakes behind each action.</0></1>
+  publicodes.AllActions.allerPlusLoin.lock: <0>Aller plus loin</0><1><0>Au-delà d'un simple chiffre, découvrez les enjeux qui se cachent derrière chaque action.</0></1>
+  publicodes.AllActions.msgPlusActions: <0>We don't have any more high-impact quantified actions to offer you 🤷</0><1>Discover below some tracks to act differently ⏬</1>
+  publicodes.AllActions.msgPlusActions.lock: <0>Nous n'avons plus d'actions chiffrées très impactantes à vous proposer 🤷</0><1>Découvrez plus bas quelques pistes pour agir autrement ⏬</1>
   publicodes.Contribution.bugQuestion: 🐛 You have a bug that prevents you from using Nos Gestes Climat?
   publicodes.Contribution.bugQuestion.lock: 🐛 Vous avez un bug qui vous empêche d'utiliser Nos Gestes Climat ?
   publicodes.Contribution.commentaireAugmenté: |-
@@ -622,328 +431,125 @@ entries:
   publicodes.Contribution.commentaireAugmenté.lock: |-
 
     > Ce ticket a été créé automatiquement par notre robot depuis notre [page de contribution](https://nosgestesclimat.fr/contribuer).
-  publicodes.Contribution.description: Here you will find answers to the most
-    frequently asked questions. If you still have questions or if you want to
-    suggest improvements, go to the bottom of the page. Have a good read!
-  publicodes.Contribution.description.lock: Vous trouverez ici les réponses aux
-    questions les plus fréquentes. S’il vous reste des interrogations ou si vous
-    souhaitez nous proposer des améliorations, rendez-vous tout en bas. Bonne
-    lecture !
-  publicodes.Contribution.descriptionComplète: <0>A complete description of your
-    problem</0><1><0>By indicating the browser you are using (e.g. Firefox
-    version 93, Chrome version 95, Safari, etc.), and the platform (iPhone,
-    Android, Windows computer, etc.), you will help us resolve the bug
-    faster.</0></1>
-  publicodes.Contribution.descriptionComplète.lock: <0>La description complète de
-    votre problème</0><1><0>En indiquant le navigateur que vous utilisez (par
-    exemple Firefox version 93, Chrome version 95, Safari, etc.), et la
-    plateforme (iPhone, Android, ordinateur Windows, etc.), vous nous aiderez à
-    résoudre le bug plus rapidement.</0></1>
+  publicodes.Contribution.description: Here you will find answers to the most frequently asked questions. If you still have questions or if you want to suggest improvements, go to the bottom of the page. Have a good read!
+  publicodes.Contribution.description.lock: Vous trouverez ici les réponses aux questions les plus fréquentes. S’il vous reste des interrogations ou si vous souhaitez nous proposer des améliorations, rendez-vous tout en bas. Bonne lecture !
+  publicodes.Contribution.descriptionComplète: <0>A complete description of your problem</0><1><0>By indicating the browser you are using (e.g. Firefox version 93, Chrome version 95, Safari, etc.), and the platform (iPhone, Android, Windows computer, etc.), you will help us resolve the bug faster.</0></1>
+  publicodes.Contribution.descriptionComplète.lock: <0>La description complète de votre problème</0><1><0>En indiquant le navigateur que vous utilisez (par exemple Firefox version 93, Chrome version 95, Safari, etc.), et la plateforme (iPhone, Android, ordinateur Windows, etc.), vous nous aiderez à résoudre le bug plus rapidement.</0></1>
   publicodes.Contribution.descriptionComplèteTraduction: <0>The complete description of your problem</0>
   publicodes.Contribution.descriptionComplèteTraduction.lock: <0>La description complète de votre problème</0>
-  publicodes.Contribution.liensVersGithub: For any comments or questions, we
-    invite you to <2>open a ticket directly on GitHub</2>.
-  publicodes.Contribution.liensVersGithub.lock: Pour toute remarque ou question,
-    nous vous invitons à <2>ouvrir un ticket directement sur GitHub</2>.
-  publicodes.Contribution.remerciements: Thank you 😍! Follow the progress of your
-    suggestion by clicking on <1>this link</1>.
-  publicodes.Contribution.remerciements.lock: Merci 😍! Suivez l'avancement de
-    votre suggestion en cliquant sur <1>ce lien</1>.
+  publicodes.Contribution.liensVersGithub: For any comments or questions, we invite you to <2>open a ticket directly on GitHub</2>.
+  publicodes.Contribution.liensVersGithub.lock: Pour toute remarque ou question, nous vous invitons à <2>ouvrir un ticket directement sur GitHub</2>.
+  publicodes.Contribution.remerciements: Thank you 😍! Follow the progress of your suggestion by clicking on <1>this link</1>.
+  publicodes.Contribution.remerciements.lock: Merci 😍! Suivez l'avancement de votre suggestion en cliquant sur <1>ce lien</1>.
   publicodes.Contribution.titreQuestion: I have another question
   publicodes.Contribution.titreQuestion.lock: J'ai une autre question
-  publicodes.Contribution.traductionIntro: Nos Gestes Climat has just been
-    translated into several languages. Do not hesitate to share your doubts
-    about a translation problem on the site 😊. We will take it into account
-    quickly.
-  publicodes.Contribution.traductionIntro.lock: Nos Gestes Climat vient tout juste
-    d'être traduit dans plusieurs langues. N'hésitez pas à vous faire part de
-    vos doutes quand à un problèm de traduction sur le site 😊. Nous le
-    prendrons en compte rapidement.
-  publicodes.Contribution.translationWikiInvite: 'Follow our complete guide to
-    contribute directly to the translation of the site: <2>go to our wiki</2>.'
-  publicodes.Contribution.translationWikiInvite.lock: 'Suivez notre guide complet
-    pour contribuer directement à la traduction du site : <2>rendez-vous sur
-    notre wiki</2>.'
+  publicodes.Contribution.traductionIntro: Nos Gestes Climat has just been translated into several languages. Do not hesitate to share your doubts about a translation problem on the site 😊. We will take it into account quickly.
+  publicodes.Contribution.traductionIntro.lock: Nos Gestes Climat vient tout juste d'être traduit dans plusieurs langues. N'hésitez pas à vous faire part de vos doutes quand à un problèm de traduction sur le site 😊. Nous le prendrons en compte rapidement.
+  publicodes.Contribution.translationWikiInvite: 'Follow our complete guide to contribute directly to the translation of the site: <2>go to our wiki</2>.'
+  publicodes.Contribution.translationWikiInvite.lock: 'Suivez notre guide complet pour contribuer directement à la traduction du site : <2>rendez-vous sur notre wiki</2>.'
   publicodes.Landing.question: Do you know your climate footprint?
   publicodes.Landing.question.lock: Connaissez-vous votre empreinte sur le climat ?
   publicodes.LandingExplanations.question: Do you know your climate footprint?
   publicodes.LandingExplanations.question.lock: Connaissez-vous votre empreinte sur le climat ?
-  publicodes.Personas.description: Personas will allow us to take the side of a
-    diversity of users when they see our "take action" screen.
-  publicodes.Personas.description.lock: Les personas nous permettront de prendre
-    le parti d'une diversité d'utilisateurs quand ils voient notamment notre
-    écran "passer à l'action".
+  publicodes.Personas.description: Personas will allow us to take the side of a diversity of users when they see our "take action" screen.
+  publicodes.Personas.description.lock: Les personas nous permettront de prendre le parti d'une diversité d'utilisateurs quand ils voient notamment notre écran "passer à l'action".
   publicodes.Personas.lienGenerateur: For the first names, you can use <2>this generator</2>
   publicodes.Personas.lienGenerateur.lock: Pour les prénoms, on peut utiliser <2>ce générateur</2>
-  publicodes.Personas.tuto: that it happens. You can either copy and paste data
-    from another persona and modify it, or create one from scratch from the
-    simulation. Once the simulation is satisfactory, click on "Modify my
-    answers" then type Ctrl-C, open the browser console (F12), make sure you are
-    in the "Console" tab, go to the very bottom of the console (it is a bit
-    busy...), then copy the JSON displayed, paste it into <2>this tool</2> to
-    generate a YAML, then insert it into personas.yaml.
-  publicodes.Personas.tuto.lock: que ça se passe. On peut soit copier coller les
-    données d'un autre persona et les modifier, soit en créer un de zéro depuis
-    la simulation. Une fois la simulation satisfaisante, cliquer sur "Modifier
-    mes réponses" puis taper Ctrl-C, ouvrir la console du navigateur (F12),
-    vérifiez bien que vous êtes dans l'onglet "Console", allez tout en bas de la
-    console (elle est un peu chargée...), puis copier le JSON affiché, le coller
-    dans <2>cet outil</2> pour générer un YAML, puis l'insérer dans
-    personas.yaml.
-  publicodes.Personas.warningMsg: 'Be careful, you have a simulation in progress:
-    selecting a persona will overwrite your simulation.'
-  publicodes.Personas.warningMsg.lock: 'Attention, vous avez une simulation en
-    cours : sélectionner un persona écrasera votre simulation.'
-  publicodes.Profil.locationDonnées: <0>Where is my data? </0>Your data is stored
-    in your browser, so you have full control over it <2></2>
-  publicodes.Profil.locationDonnées.lock: <0>Où sont mes données ? </0>Vos données
-    sont stockées dans votre navigateur, vous avez donc le contrôle total sur
-    elles. <2></2>
-  publicodes.Profil.recap: You have completed {{percentFinished}}% of the test
-    ({{answeredQuestionsLength}} questions) and chosen {{actionChoicesLength}}
-    actions.
-  publicodes.Profil.recap.lock: Vous avez terminé le test à {{percentFinished}} %
-    ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}}
-    actions.
-  publicodes.SimulationMissing.personnas: 💡 You can also see the action course as
-    if you were one of these sample profiles.
-  publicodes.SimulationMissing.personnas.lock: 💡 Vous pouvez aussi voir le
-    parcours action comme si vous étiez l'un de ces profils types.
-  publicodes.SimulationMissing.simulationManquante: You haven't taken the test
-    yet. To unlock this course, you need to tell us a little more about your
-    lifestyle.
-  publicodes.SimulationMissing.simulationManquante.lock: Vous n'avez pas encore
-    fait le test. Pour débloquer ce parcours, vous devez nous en dire un peu
-    plus sur votre mode de vie.
+  publicodes.Personas.tuto: that it happens. You can either copy and paste data from another persona and modify it, or create one from scratch from the simulation. Once the simulation is satisfactory, click on "Modify my answers" then type Ctrl-C, open the browser console (F12), make sure you are in the "Console" tab, go to the very bottom of the console (it is a bit busy...), then copy the JSON displayed, paste it into <2>this tool</2> to generate a YAML, then insert it into personas.yaml.
+  publicodes.Personas.tuto.lock: que ça se passe. On peut soit copier coller les données d'un autre persona et les modifier, soit en créer un de zéro depuis la simulation. Une fois la simulation satisfaisante, cliquer sur "Modifier mes réponses" puis taper Ctrl-C, ouvrir la console du navigateur (F12), vérifiez bien que vous êtes dans l'onglet "Console", allez tout en bas de la console (elle est un peu chargée...), puis copier le JSON affiché, le coller dans <2>cet outil</2> pour générer un YAML, puis l'insérer dans personas.yaml.
+  publicodes.Personas.warningMsg: 'Be careful, you have a simulation in progress: selecting a persona will overwrite your simulation.'
+  publicodes.Personas.warningMsg.lock: 'Attention, vous avez une simulation en cours : sélectionner un persona écrasera votre simulation.'
+  publicodes.Profil.locationDonnées: <0>Where is my data? </0>Your data is stored in your browser, so you have full control over it <2></2>
+  publicodes.Profil.locationDonnées.lock: <0>Où sont mes données ? </0>Vos données sont stockées dans votre navigateur, vous avez donc le contrôle total sur elles. <2></2>
+  publicodes.Profil.recap: You have completed {{percentFinished}}% of the test ({{answeredQuestionsLength}} questions) and chosen {{actionChoicesLength}} actions.
+  publicodes.Profil.recap.lock: Vous avez terminé le test à {{percentFinished}} % ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}} actions.
+  publicodes.SimulationMissing.personnas: 💡 You can also see the action course as if you were one of these sample profiles.
+  publicodes.SimulationMissing.personnas.lock: 💡 Vous pouvez aussi voir le parcours action comme si vous étiez l'un de ces profils types.
+  publicodes.SimulationMissing.simulationManquante: You haven't taken the test yet. To unlock this course, you need to tell us a little more about your lifestyle.
+  publicodes.SimulationMissing.simulationManquante.lock: Vous n'avez pas encore fait le test. Pour débloquer ce parcours, vous devez nous en dire un peu plus sur votre mode de vie.
   publicodes.TranslationContribution.commentaireAugmenté: |-
 
     &gt; This ticket was created automatically by our robot from our [translation contribution page](https://nosgestesclimat.fr/contribuer-traduction).
   publicodes.TranslationContribution.commentaireAugmenté.lock: |-
 
     > Ce ticket a été créé automatiquement par notre robot depuis notre [page de contribution pour la traduction](https://nosgestesclimat.fr/contribuer-traduction).
-  publicodes.TranslationContribution.remerciements: Thank you 😍! Follow the
-    progress of your suggestion by clicking on <2>this link</2>.
-  publicodes.TranslationContribution.remerciements.lock: Merci 😍! Suivez
-    l'avancement de votre suggestion en cliquant sur <2>ce lien</2>.
-  publicodes.Tutorial.slide1.p1: <0>Do not worry, we'll briefly explain what it
-    is.</0><1>The planet is <1>warming up dangerously</1>, as we emit more and
-    more greenhouse gases.</1>
-  publicodes.Tutorial.slide1.p1.lock: <0>Pas de panique, on vous explique ce que
-    c'est.</0><1>La planète <1>se réchauffe dangereusement</1>, au fur et à
-    mesure des gaz à effet de serre que l'on émet.</1>
-  publicodes.Tutorial.slide1.p2: <0>This test gives you in ⏱️ 10 minutes flat <2>a
-    measure of your part </2> in this warming.</0>
-  publicodes.Tutorial.slide1.p2.lock: <0>Ce test vous donne en ⏱️ 10 minutes
-    chrono <2>une mesure de votre part </2> dans ce réchauffement.</0>
-  publicodes.Tutorial.slide2.blockquote: 'Other gases, especially methane <2></2>
-    and nitrous oxide <6></6> also warm the planet: we convert their warming
-    potential to CO₂ equivalent to simplify the measurement. '
-  publicodes.Tutorial.slide2.blockquote.lock: "D'autres gaz, surtout le méthane
-    <2></2> et le protoxyde d'azote <6></6> réchauffent aussi la planète : on
-    convertit leur potentiel de réchauffement en équivalent CO₂ pour simplifier
-    la mesure. "
+  publicodes.TranslationContribution.remerciements: Thank you 😍! Follow the progress of your suggestion by clicking on <2>this link</2>.
+  publicodes.TranslationContribution.remerciements.lock: Merci 😍! Suivez l'avancement de votre suggestion en cliquant sur <2>ce lien</2>.
+  publicodes.Tutorial.slide1.p1: <0>Do not worry, we'll briefly explain what it is.</0><1>The planet is <1>warming up dangerously</1>, as we emit more and more greenhouse gases.</1>
+  publicodes.Tutorial.slide1.p1.lock: <0>Pas de panique, on vous explique ce que c'est.</0><1>La planète <1>se réchauffe dangereusement</1>, au fur et à mesure des gaz à effet de serre que l'on émet.</1>
+  publicodes.Tutorial.slide1.p2: <0>This test gives you in ⏱️ 10 minutes flat <2>a measure of your part </2> in this warming.</0>
+  publicodes.Tutorial.slide1.p2.lock: <0>Ce test vous donne en ⏱️ 10 minutes chrono <2>une mesure de votre part </2> dans ce réchauffement.</0>
+  publicodes.Tutorial.slide2.blockquote: 'Other gases, especially methane <2></2> and nitrous oxide <6></6> also warm the planet: we convert their warming potential to CO₂ equivalent to simplify the measurement. '
+  publicodes.Tutorial.slide2.blockquote.lock: "D'autres gaz, surtout le méthane <2></2> et le protoxyde d'azote <6></6> réchauffent aussi la planète : on convertit leur potentiel de réchauffement en équivalent CO₂ pour simplifier la mesure. "
   publicodes.Tutorial.slide2.p1: |
     Through a unit with a barbaric name: the CO₂
     equivalent. You already know carbon dioxide<1></1>, it's what we breathe out all day,
     but without influence on the climate.
-  publicodes.Tutorial.slide2.p1.lock: "Avec une unité au nom barbare :
-    l'équivalent CO₂. Le dioxyde de carbone<1></1>, vous le connaissez : on
-    l'expire toute la journée, mais sans influence sur le climat."
-  publicodes.Tutorial.slide2.p2: Machines that enable our modern comfort do emit
-    massive amounts of CO₂, so much that we count it in thousands of kilos per
-    year and per person, therefore in <1>tonnes</1> of CO₂e!
-  publicodes.Tutorial.slide2.p2.lock: Ce sont les machines qui font notre confort
-    moderne qui en rejettent massivement, à tel point qu'on le compte en
-    milliers de kilos par an et par personne, donc en <1>tonnes</1> de CO₂e !
-  publicodes.Tutorial.slide5.p1: <0>And the goal?</0><1>We have to decrease our
-    climate footprint as soon as possible.</1><2>In France, this means going
-    from ~10 tonnes to <2>less than 2 tonnes</2> per year.</2>
-  publicodes.Tutorial.slide5.p1.lock: <0>Et l'objectif ?</0><1>Nous devons
-    diminuer notre empreinte climat au plus vite.</1><2>En France, ça consiste à
-    passer de ~10 tonnes à <2>moins de 2 tonnes</2> par an.</2>
-  publicodes.Tutorial.slide6: <0>Where does our footprint come from?</0><1>Taking
-    the car, eating a steak, heating your house, getting medical care, buying a
-    TV...</1><2><0><0></0></0></2><3>The footprint of our individual consumption
-    is the sum of all these activities that make up our modern life </3>
-  publicodes.Tutorial.slide6.lock: <0>D'où vient notre empreinte ?</0><1>Prendre
-    la voiture, manger un steak, chauffer sa maison, se faire soigner, acheter
-    une TV...</1><2><0><0></0></0></2><3>L'empreinte de notre consommation
-    individuelle, c'est la somme de toutes ces activités qui font notre vie
-    moderne. </3>
-  publicodes.Tutorial.slide7: '<0>So, are you ready to go?</0><1>Some tips to help
-    you complete the test:</1><2>👤 Answer the questions on behalf of yourself,
-    not your household: this is an individual test.</2><3>💼 Answer for your
-    personal life, not for your job or studies. <2>One exception: </2> your
-    commute must be included in the miles driven.</3><4>❓️ More questions? Check
-    out our <2>FAQs</2> at any time.</4>'
-  publicodes.Tutorial.slide7.lock: "<0>Alors, c'est parti ?</0><1>Quelques astuces
-    pour vous aider à compléter le test :</1><2>👤 Répondez aux questions en
-    votre nom, pas au nom de votre foyer : c'est un test individuel.</2><3>💼
-    Répondez pour votre vie perso, pas pour votre boulot ou études. <2>Une seule
-    exception </2>: votre trajet domicile-travail doit être inclus dans les km
-    parcourus.</3><4>❓️ D'autres questions ? Consultez notre <2>FAQ</2> à tout
-    moment.</4>"
+  publicodes.Tutorial.slide2.p1.lock: "Avec une unité au nom barbare : l'équivalent CO₂. Le dioxyde de carbone<1></1>, vous le connaissez : on l'expire toute la journée, mais sans influence sur le climat."
+  publicodes.Tutorial.slide2.p2: Machines that enable our modern comfort do emit massive amounts of CO₂, so much that we count it in thousands of kilos per year and per person, therefore in <1>tonnes</1> of CO₂e!
+  publicodes.Tutorial.slide2.p2.lock: Ce sont les machines qui font notre confort moderne qui en rejettent massivement, à tel point qu'on le compte en milliers de kilos par an et par personne, donc en <1>tonnes</1> de CO₂e !
+  publicodes.Tutorial.slide5.p1: <0>And the goal?</0><1>We have to decrease our climate footprint as soon as possible.</1><2>In France, this means going from ~10 tonnes to <2>less than 2 tonnes</2> per year.</2>
+  publicodes.Tutorial.slide5.p1.lock: <0>Et l'objectif ?</0><1>Nous devons diminuer notre empreinte climat au plus vite.</1><2>En France, ça consiste à passer de ~10 tonnes à <2>moins de 2 tonnes</2> par an.</2>
+  publicodes.Tutorial.slide6: <0>Where does our footprint come from?</0><1>Taking the car, eating a steak, heating your house, getting medical care, buying a TV...</1><2><0><0></0></0></2><3>The footprint of our individual consumption is the sum of all these activities that make up our modern life </3>
+  publicodes.Tutorial.slide6.lock: <0>D'où vient notre empreinte ?</0><1>Prendre la voiture, manger un steak, chauffer sa maison, se faire soigner, acheter une TV...</1><2><0><0></0></0></2><3>L'empreinte de notre consommation individuelle, c'est la somme de toutes ces activités qui font notre vie moderne. </3>
+  publicodes.Tutorial.slide7: '<0>So, are you ready to go?</0><1>Some tips to help you complete the test:</1><2>👤 Answer the questions on behalf of yourself, not your household: this is an individual test.</2><3>💼 Answer for your personal life, not for your job or studies. <2>One exception: </2> your commute must be included in the miles driven.</3><4>❓️ More questions? Check out our <2>FAQs</2> at any time.</4>'
+  publicodes.Tutorial.slide7.lock: "<0>Alors, c'est parti ?</0><1>Quelques astuces pour vous aider à compléter le test :</1><2>👤 Répondez aux questions en votre nom, pas au nom de votre foyer : c'est un test individuel.</2><3>💼 Répondez pour votre vie perso, pas pour votre boulot ou études. <2>Une seule exception </2>: votre trajet domicile-travail doit être inclus dans les km parcourus.</3><4>❓️ D'autres questions ? Consultez notre <2>FAQ</2> à tout moment.</4>"
   publicodes.chart.GridChart.equivalenceCase: One box 🔲 = {{nbKg}} kg of CO₂e.
   publicodes.chart.GridChart.equivalenceCase.lock: Une case 🔲 = {{nbKg}} kg de CO₂e.
-  publicodes.conference.Conference.donnéesExplications: '<0>By participating, you
-    agree to share your aggregated simulation results with other conference
-    participants: the total and the categories (transportation, housing, etc.).
-    However, our servers do not store them: it works in P2P (peer to
-    peer).</0><1>Only the name of the conference room will be indexed in <2>the
-    usage statistics</2> of Our Climate Action </1>'
-  publicodes.conference.Conference.donnéesExplications.lock: "<0>En participant,
-    vous acceptez de partager vos résultats agrégés de simulation avec les
-    autres participants de la conférence : le total et les catégories
-    (transport, logement, etc.). En revanche, nos serveurs ne les stockent pas :
-    cela fonctionne en P2P (pair à pair).</0><1>Seul le nom de la salle de
-    conférence sera indexé dans <2>les statistiques d'utilisation</2> de Nos
-    Gestes Climat. </1>"
-  publicodes.conference.DataWarning.explanation: 'The principle is simple: each
-    person takes a test on his or her own device, and the results are shared in
-    real time with the other participants in the survey.'
-  publicodes.conference.DataWarning.explanation.lock: 'Le principe est simple :
-    chacun fait son test sur son appareil, et les résultats sont mis en commun
-    en temps réel avec les autres participants du sondage.'
-  publicodes.conference.DataWarning.viePrivée: '🕵 By participating, you agree to
-    the <1>anonymous</1> collection of your aggregated simulation results on our
-    server: total climate footprint and categories (transportation, housing,
-    etc.). <3>Read more</3>'
-  publicodes.conference.DataWarning.viePrivée.lock: "🕵 En participant, vous
-    acceptez la collecte <1>anonyme</1> de vos résultats agrégés de simulation
-    sur notre serveur : l'empreinte climat totale et les catégories (transport,
-    logement, etc.). <3>En savoir plus</3>"
-  publicodes.conference.Instructions.avertissementModeConference: '<0>Be careful</0>, it is possible that your organization blocks
-    peer-to-peer, and therefore the use of the conference mode. Test beforehand
-    on site and in duet: in case of problem, you can use the survey mode.'
-  publicodes.conference.Instructions.avertissementModeConference.lock: "<0>Attention</0>, il est possible que votre organisation bloque le
-    pair-à-pair, et donc l'utilisation du mode conférence. Faites le test au
-    préalable sur site et en duo : en cas de problème, vous pouvez utiliser le
-    mode sondage."
-  publicodes.conference.Instructions.contextualisationLink: 💡 Want to add
-    questions to get additional information about respondents? <2>Check out the
-    "survey contextualization!" feature </2>
-  publicodes.conference.Instructions.contextualisationLink.lock: 💡 Vous souhaitez ajouter des questions pour obtenir des informations
-    supplémentaires sur les répondants ? <2>Découvrez la fonctionnalité
-    "contextualisation de sondage !" </2>
-  publicodes.conference.Instructions.descriptionModeConference: 'Ephemeral mode: perfect for a workshop, an interactive presentation or
-    between friends. The data remains between the participants (peer-to-peer
-    without server), <2>just the time of the conference</2>.'
-  publicodes.conference.Instructions.descriptionModeConference.lock: "Mode éphémère : parfait pour l'animation d'un atelier, une présentation
-    interactive ou entre amis. Les données restent entre les participants
-    (pair-à-pair sans serveur), <2>juste le temps de la conférence</2>."
-  publicodes.conference.Instructions.descriptionModeSondage: 'Persistent mode:
-    participant data is stored on our server and remains accessible and
-    downloadable <2>for two months</2>.'
-  publicodes.conference.Instructions.descriptionModeSondage.lock: 'Mode persistant : les données des participants sont stockées sur notre
-    serveur et restent accessibles et téléchargeables <2>pendant deux mois</2>.'
-  publicodes.conference.Instructions.guideLien: The results are in, what to do?
-    Our guide accompanies you in your thoughts and discussions on this page
-  publicodes.conference.Instructions.guideLien.lock: Les résultats sont là, que
-    faire ? Notre guide vous accompagne dans vos réflexions et vos discussions
-    sur cette page
-  publicodes.conference.Instructions.intro: <0>The climate footprint test is an
-    individual test, but here we suggest that you do it with others. Everyone
-    will be behind his or her screen, but will be able to see the results of the
-    others in real time.</0><1>It is an opportunity to think together about the
-    stakes of our own impact by comparing our lifestyles.</1>
-  publicodes.conference.Instructions.intro.lock: <0>Le test d'empreinte climat est
-    individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun
-    sera derrière son écran, mais visualisera en temps réel les résultats des
-    autres.</0><1>C'est l'occasion de réfléchir ensemble aux enjeux de notre
-    propre impact en comparant nos modes de vie.</1>
-  publicodes.conference.Instructions.liensSimulationConference: At the agreed time, open this link all at the same time and do your own
-    simulation.
-  publicodes.conference.Instructions.liensSimulationConference.lock: Au moment convenu, ouvrez ce lien tous en même temps et faites chacun de
-    votre côté votre simulation.
+  publicodes.conference.Conference.donnéesExplications: '<0>By participating, you agree to share your aggregated simulation results with other conference participants: the total and the categories (transportation, housing, etc.). However, our servers do not store them: it works in P2P (peer to peer).</0><1>Only the name of the conference room will be indexed in <2>the usage statistics</2> of Our Climate Action </1>'
+  publicodes.conference.Conference.donnéesExplications.lock: "<0>En participant, vous acceptez de partager vos résultats agrégés de simulation avec les autres participants de la conférence : le total et les catégories (transport, logement, etc.). En revanche, nos serveurs ne les stockent pas : cela fonctionne en P2P (pair à pair).</0><1>Seul le nom de la salle de conférence sera indexé dans <2>les statistiques d'utilisation</2> de Nos Gestes Climat. </1>"
+  publicodes.conference.DataWarning.explanation: 'The principle is simple: each person takes a test on his or her own device, and the results are shared in real time with the other participants in the survey.'
+  publicodes.conference.DataWarning.explanation.lock: 'Le principe est simple : chacun fait son test sur son appareil, et les résultats sont mis en commun en temps réel avec les autres participants du sondage.'
+  publicodes.conference.DataWarning.viePrivée: '🕵 By participating, you agree to the <1>anonymous</1> collection of your aggregated simulation results on our server: total climate footprint and categories (transportation, housing, etc.). <3>Read more</3>'
+  publicodes.conference.DataWarning.viePrivée.lock: "🕵 En participant, vous acceptez la collecte <1>anonyme</1> de vos résultats agrégés de simulation sur notre serveur : l'empreinte climat totale et les catégories (transport, logement, etc.). <3>En savoir plus</3>"
+  publicodes.conference.Instructions.avertissementModeConference: '<0>Be careful</0>, it is possible that your organization blocks peer-to-peer, and therefore the use of the conference mode. Test beforehand on site and in duet: in case of problem, you can use the survey mode.'
+  publicodes.conference.Instructions.avertissementModeConference.lock: "<0>Attention</0>, il est possible que votre organisation bloque le pair-à-pair, et donc l'utilisation du mode conférence. Faites le test au préalable sur site et en duo : en cas de problème, vous pouvez utiliser le mode sondage."
+  publicodes.conference.Instructions.contextualisationLink: 💡 Want to add questions to get additional information about respondents? <2>Check out the "survey contextualization!" feature </2>
+  publicodes.conference.Instructions.contextualisationLink.lock: 💡 Vous souhaitez ajouter des questions pour obtenir des informations supplémentaires sur les répondants ? <2>Découvrez la fonctionnalité "contextualisation de sondage !" </2>
+  publicodes.conference.Instructions.descriptionModeConference: 'Ephemeral mode: perfect for a workshop, an interactive presentation or between friends. The data remains between the participants (peer-to-peer without server), <2>just the time of the conference</2>.'
+  publicodes.conference.Instructions.descriptionModeConference.lock: "Mode éphémère : parfait pour l'animation d'un atelier, une présentation interactive ou entre amis. Les données restent entre les participants (pair-à-pair sans serveur), <2>juste le temps de la conférence</2>."
+  publicodes.conference.Instructions.descriptionModeSondage: 'Persistent mode: participant data is stored on our server and remains accessible and downloadable <2>for two months</2>.'
+  publicodes.conference.Instructions.descriptionModeSondage.lock: 'Mode persistant : les données des participants sont stockées sur notre serveur et restent accessibles et téléchargeables <2>pendant deux mois</2>.'
+  publicodes.conference.Instructions.guideLien: The results are in, what to do? Our guide accompanies you in your thoughts and discussions on this page
+  publicodes.conference.Instructions.guideLien.lock: Les résultats sont là, que faire ? Notre guide vous accompagne dans vos réflexions et vos discussions sur cette page
+  publicodes.conference.Instructions.intro: <0>The climate footprint test is an individual test, but here we suggest that you do it with others. Everyone will be behind his or her screen, but will be able to see in real time the results of the others.</0><1>It is an opportunity to think together about the stakes of our own impact by comparing our lifestyles.</1>
+  publicodes.conference.Instructions.intro.lock: <0>Le test d'empreinte climat est individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun sera derrière son écran, mais pourra voir en temps réel les résultats des autres.</0><1>C'est l'occasion de réfléchir ensemble aux enjeux de notre propre impact en comparant nos modes de vie.</1>
+  publicodes.conference.Instructions.liensSimulationConference: At the agreed time, open this link all at the same time and do your own simulation.
+  publicodes.conference.Instructions.liensSimulationConference.lock: Au moment convenu, ouvrez ce lien tous en même temps et faites chacun de votre côté votre simulation.
   publicodes.conference.Instructions.liensSimulationSondage: Participants must come to make their simulation on this link.
   publicodes.conference.Instructions.liensSimulationSondage.lock: Les participants doivent venir faire leur simulation sur ce lien.
-  publicodes.conference.Instructions.resultatInfos: 'The results for each category
-    (food, transportation, housing, etc.) are displayed progressively and in
-    real time for the entire group on '
-  publicodes.conference.Instructions.resultatInfos.lock: "Les résultats pour
-    chaque catégorie (alimentation, transport, logement ...) s'affichent
-    progressivement et en temps réel pour l'ensemble du groupe sur "
+  publicodes.conference.Instructions.resultatInfos: 'The results for each category (food, transportation, housing, etc.) are displayed progressively and in real time for the entire group on '
+  publicodes.conference.Instructions.resultatInfos.lock: "Les résultats pour chaque catégorie (alimentation, transport, logement ...) s'affichent progressivement et en temps réel pour l'ensemble du groupe sur "
   publicodes.conference.NamingBlock.nomSalleCourt: ⚠️ Your room name is short, there is a small risk that strangers may guess it
-  publicodes.conference.NamingBlock.nomSalleCourt.lock: ⚠️ Votre nom de salle est
-    court, il y a un petit risque que des inconnus puissent le deviner
+  publicodes.conference.NamingBlock.nomSalleCourt.lock: ⚠️ Votre nom de salle est court, il y a un petit risque que des inconnus puissent le deviner
   publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres: 💡 Your room name can only contain letters, numbers and dashes
-  publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres.lock: 💡 Votre nom de salle ne peut que contenir des lettres, des chiffres et des
-    tirets
-  publicodes.conference.NoTestMessage.bienvenue: Welcome to the group mode of Our
-    Climate Action! You haven't started your test yet, go ahead!
-  publicodes.conference.NoTestMessage.bienvenue.lock: Bienvenue dans le mode
-    groupe de Nos Gestes Climat ! Vous n'avez pas encore débuté votre test,
-    lancez-vous !
+  publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres.lock: 💡 Votre nom de salle ne peut que contenir des lettres, des chiffres et des tirets
+  publicodes.conference.NoTestMessage.bienvenue: Welcome to the group mode of Our Climate Action! You haven't started your test yet, go ahead!
+  publicodes.conference.NoTestMessage.bienvenue.lock: Bienvenue dans le mode groupe de Nos Gestes Climat ! Vous n'avez pas encore débuté votre test, lancez-vous !
   publicodes.conference.Survey.csv: You can retrieve the survey results in .csv format.
   publicodes.conference.Survey.csv.lock: Vous pouvez récupérer les résultats du sondage dans le format .csv.
-  publicodes.conference.Survey.excel: 'To open it with Microsoft Excel, open an
-    empty spreadsheet, then Data &gt; From a text / CSV file. Select "Origin:
-    Unicode UTF-8" and "Delimiter: comma".'
-  publicodes.conference.Survey.excel.lock: 'Pour l''ouvrir avec Microsoft Excel,
-    ouvrez un tableur vide, puis Données > À partir d''un fichier texte / CSV.
-    Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
+  publicodes.conference.Survey.excel: 'To open it with Microsoft Excel, open an empty spreadsheet, then Data &gt; From a text / CSV file. Select "Origin: Unicode UTF-8" and "Delimiter: comma".'
+  publicodes.conference.Survey.excel.lock: 'Pour l''ouvrir avec Microsoft Excel, ouvrez un tableur vide, puis Données > À partir d''un fichier texte / CSV. Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
   publicodes.conference.Survey.libreOffice: To open it with <2>LibreOffice</2>, it is automatic.
   publicodes.conference.Survey.libreOffice.lock: Pour l'ouvrir avec <2>LibreOffice</2>, c'est automatique.
-  publicodes.conference.Survey.notCreatedWarning1: Please note that there are no
-    polls at this address. To launch a poll, the organizer must first create it
-    on the <2>group mode</2> page.
-  publicodes.conference.Survey.notCreatedWarning1.lock: Attention, il n'existe
-    aucun sondage à cette adresse. Pour lancer un sondage, l'organisateur doit
-    d'abord le créer sur la page du <2>mode groupe</2>.
-  publicodes.conference.Survey.notCreatedWarning2: Perhaps you made a typo in the
-    survey address? Remember to use the correct capitalization, copy and paste
-    the exact address or use the QR code.
-  publicodes.conference.Survey.notCreatedWarning2.lock: Peut-être avez-vous fait
-    une faute de frappe dans l'adresse du sondage ? Pensez notamment à bien
-    respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le
-    QR code.
-  publicodes.conference.Survey.resultat: The results on the view page only include
-    participants who completed <1>at least 10% of the test</1>. The CSV, on the
-    other hand, contains the simulations of all the people who participated in
-    the survey by clicking on the link. The "progress" column allows you to
-    filter the simulations in turn.
-  publicodes.conference.Survey.resultat.lock: Les résultats de la page de
-    visualisation ne prennent en compte que les participants ayant rempli <1>au
-    moins 10% du test</1>. En revanche le CSV contient les simulations de toutes
-    les personnes ayant participé au sondage en cliquant sur le lien. La colonne
-    "progress" vous permet de filtrer les simulations à votre tour.
+  publicodes.conference.Survey.notCreatedWarning1: Please note that there are no polls at this address. To launch a poll, the organizer must first create it on the <2>group mode</2> page.
+  publicodes.conference.Survey.notCreatedWarning1.lock: Attention, il n'existe aucun sondage à cette adresse. Pour lancer un sondage, l'organisateur doit d'abord le créer sur la page du <2>mode groupe</2>.
+  publicodes.conference.Survey.notCreatedWarning2: Perhaps you made a typo in the survey address? Remember to use the correct capitalization, copy and paste the exact address or use the QR code.
+  publicodes.conference.Survey.notCreatedWarning2.lock: Peut-être avez-vous fait une faute de frappe dans l'adresse du sondage ? Pensez notamment à bien respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le QR code.
+  publicodes.conference.Survey.resultat: The results on the view page only include participants who completed <1>at least 10% of the test</1>. The CSV, on the other hand, contains the simulations of all the people who participated in the survey by clicking on the link. The "progress" column allows you to filter the simulations in turn.
+  publicodes.conference.Survey.resultat.lock: Les résultats de la page de visualisation ne prennent en compte que les participants ayant rempli <1>au moins 10% du test</1>. En revanche le CSV contient les simulations de toutes les personnes ayant participé au sondage en cliquant sur le lien. La colonne "progress" vous permet de filtrer les simulations à votre tour.
   publicodes.fin.ActionTeaser.félicitations: '{{displayedTotal}} tonnes!<2> You are well below the French average</2> '
-  publicodes.fin.ActionTeaser.félicitations.lock: '{{displayedTotal}} tonnes !<2>
-    Vous êtes très nettement en-dessous de la moyenne française.</2> '
-  publicodes.fin.ActionTeaser.messagePourConvaincre: Chances are, your time will
-    be better spent convincing and helping others than trying to earn your
-    "extra tonnes" (although you will have to do that eventually).
-  publicodes.fin.ActionTeaser.messagePourConvaincre.lock: Il y a de grandes
-    chances que votre temps soit plus efficace à convaincre et aider les autres
-    qu'à chercher à gagner vos "tonnes en trop" (même s'il faudra le faire un
-    jour).
+  publicodes.fin.ActionTeaser.félicitations.lock: '{{displayedTotal}} tonnes !<2> Vous êtes très nettement en-dessous de la moyenne française.</2> '
+  publicodes.fin.ActionTeaser.messagePourConvaincre: Chances are, your time will be better spent convincing and helping others than trying to earn your "extra tonnes" (although you will have to do that eventually).
+  publicodes.fin.ActionTeaser.messagePourConvaincre.lock: Il y a de grandes chances que votre temps soit plus efficace à convaincre et aider les autres qu'à chercher à gagner vos "tonnes en trop" (même s'il faudra le faire un jour).
   publicodes.fin.IframeDataShareModal.partageResultats: Share your results at {{parent}}?
   publicodes.fin.IframeDataShareModal.partageResultats.lock: Partage de vos résultats à {{parent}} ?
-  publicodes.fin.IframeDataShareModal.text: <0>By clicking on the Accept button,
-    you authorize {{parent}} à récupérer le bilan de votre empreinte
-    climat.</0><1>These are your results on the main categories (transport,
-    food...), but <1>not</1> the details of each question (your car kilometers,
-    the m² of your house...).</1><2>Nosgestesclimat.fr n'est pas affilié au site
-    {{parent}}.</2>
-  publicodes.fin.IframeDataShareModal.text.lock: <0>En cliquant sur le bouton
-    Accepter, vous autorisez {{parent}} à récupérer le bilan de votre empreinte
-    climat.</0><1>Il s'agit de vos résultats sur les grandes catégories
-    (transport, alimentation...), mais <1>pas</1> le détail question par
-    question (vos km en voiture, les m² de votre
-    logement...).</1><2>Nosgestesclimat.fr n'est pas affilié au site
-    {{parent}}.</2>
+  publicodes.fin.IframeDataShareModal.text: <0>By clicking on the Accept button, you authorize {{parent}} à récupérer le bilan de votre empreinte climat.</0><1>These are your results on the main categories (transport, food...), but <1>not</1> the details of each question (your car kilometers, the m² of your house...).</1><2>Nosgestesclimat.fr n'est pas affilié au site {{parent}}.</2>
+  publicodes.fin.IframeDataShareModal.text.lock: <0>En cliquant sur le bouton Accepter, vous autorisez {{parent}} à récupérer le bilan de votre empreinte climat.</0><1>Il s'agit de vos résultats sur les grandes catégories (transport, alimentation...), mais <1>pas</1> le détail question par question (vos km en voiture, les m² de votre logement...).</1><2>Nosgestesclimat.fr n'est pas affilié au site {{parent}}.</2>
   publicodes.fin.Petrogaz.equivalenceVolume: That is to say {{secondaryValue}} litres (plein de {{pleinVolume}} liters).
   publicodes.fin.Petrogaz.equivalenceVolume.lock: Soit {{secondaryValue}} litres (plein de {{pleinVolume}} litres).
-  publicodes.fin.Petrogaz.explications: <0>It is a <1>minimum</1> estimate of your
-    crude oil consumption for the year.</0><1>Estimated via your car, plane, bus
-    and heating oil consumption, it does not (yet) take into account the oil
-    used to transport your purchases, and the grey energy of your various
-    possessions.</1>
-  publicodes.fin.Petrogaz.explications.lock: <0>C'est une estimation <1>a
-    minima</1> de votre consommation de pétrole brut à l'année.</0><1>Estimée
-    via vos trajets en voiture, en avion, en bus, consommation de fioul pour
-    chauffage, elle ne prend pas (encore) en compte le pétrole utilisé pour
-    acheminer vos achats, et l'énergie grise de vos diverses possessions.</1>
+  publicodes.fin.Petrogaz.explications: <0>It is a <1>minimum</1> estimate of your crude oil consumption for the year.</0><1>Estimated via your car, plane, bus and heating oil consumption, it does not (yet) take into account the oil used to transport your purchases, and the grey energy of your various possessions.</1>
+  publicodes.fin.Petrogaz.explications.lock: <0>C'est une estimation <1>a minima</1> de votre consommation de pétrole brut à l'année.</0><1>Estimée via vos trajets en voiture, en avion, en bus, consommation de fioul pour chauffage, elle ne prend pas (encore) en compte le pétrole utilisé pour acheminer vos achats, et l'énergie grise de vos diverses possessions.</1>
   publicodes.fin.Petrogaz.petroleBrut: of <1>crude oil per year</1>
   publicodes.fin.Petrogaz.petroleBrut.lock: de <1>pétrole brut par an</1>
   période: period
@@ -959,16 +565,12 @@ entries:
   simulation-end.title.lock: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations completed since the launch
-  site.publicodes.conferences.Stats.explication0: Each vertical bar ☝️ is the
-    total score of a participant,<1></1>each disc 👇️ a score on a category.
-  site.publicodes.conferences.Stats.explication0.lock: Chaque barre verticale ☝️
-    est le score total d'un participant,<1></1>chaque disque 👇️ un score sur
-    une catégorie.
+  site.publicodes.conferences.Stats.explication0: Each vertical bar ☝️ is the total score of a participant,<1></1>each disc 👇️ a score on a category.
+  site.publicodes.conferences.Stats.explication0.lock: Chaque barre verticale ☝️ est le score total d'un participant,<1></1>chaque disque 👇️ un score sur une catégorie.
   site.publicodes.conferences.Stats.explication1: '<0>In yellow</0>: my score of {{spotlightValue}} t.'
   site.publicodes.conferences.Stats.explication1.lock: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
   sites.publicodes.Landing.description: In 10 minutes, get an estimate of your carbon footprint.
-  sites.publicodes.Landing.description.lock: En 10 minutes, obtenez une estimation
-    de votre empreinte carbone de consommation.
+  sites.publicodes.Landing.description.lock: En 10 minutes, obtenez une estimation de votre empreinte carbone de consommation.
   sites.publicodes.LandingExplanations.faqLink: |-
     ## Any questions?
 

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -34,8 +34,7 @@ entries:
   Ce guide n'existe pas encore: Ce guide n'existe pas encore
   "Cette contribution sera publique : n'y mettez pas d'informations sensibles": "Cette contribution sera publique : n'y mettez pas d'informations sensibles"
   Cette fiche détaillée n'existe pas encore: Cette fiche détaillée n'existe pas encore
-  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.: Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si
-    vous étiez l'un des profils types que nous avons listés.
+  Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.: Cette page vous permet de naviguer les parcours Nos Gestes Climat comme si vous étiez l'un des profils types que nous avons listés.
   Chargement: Chargement
   Chargement du modèle de calcul...: Chargement du modèle de calcul...
   Chargement...: Chargement...
@@ -44,6 +43,7 @@ entries:
   Choisir une autre région: Choisir une autre région
   Choisissez d'abord un nom: Choisissez d'abord un nom
   Choisissez la votre: Choisissez la votre
+  Choisissez la vôtre: Choisissez la vôtre
   Choisissez une région parmi celles disponibles !: Choisissez une région parmi celles disponibles !
   Cliquez pour partager le lien: Cliquez pour partager le lien
   Commencer: Commencer
@@ -64,8 +64,7 @@ entries:
   Courses: Courses
   De quoi est faite mon empreinte ?: De quoi est faite mon empreinte ?
   Depuis la page: Depuis la page
-  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.": Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat
-    individuelle de consommation de référence.
+  "Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.": Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.
   Diffuser: Diffuser
   Distance: Distance
   Documentation: Documentation
@@ -85,10 +84,7 @@ entries:
   En savoir +: En savoir +
   En savoir plus: En savoir plus
   'Enlever ': 'Enlever '
-  "Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un standard qui évolue régulièrement et qui peut être réutilisé librement par tout type d'acteur.": Entièrement ouvert (open source) et contributif, chacun peut
-    l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un
-    standard qui évolue régulièrement et qui peut être réutilisé librement par
-    tout type d'acteur.
+  "Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un standard qui évolue régulièrement et qui peut être réutilisé librement par tout type d'acteur.": Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>. C'est un standard qui évolue régulièrement et qui peut être réutilisé librement par tout type d'acteur.
   Entre: Entre
   Entrez des mots clefs: Entrez des mots clefs
   Entrez des mots clefs ici: Entrez des mots clefs ici
@@ -99,8 +95,7 @@ entries:
   Et mes données ?: Et mes données ?
   Explorer les catégories: Explorer les catégories
   Explorer notre documentation: Explorer notre documentation
-  Explorez et modifiez les informations que vous avez saisies dans le parcours nosgestesclimat.: Explorez et modifiez les informations que vous avez saisies dans le parcours
-    nosgestesclimat.
+  Explorez et modifiez les informations que vous avez saisies dans le parcours nosgestesclimat.: Explorez et modifiez les informations que vous avez saisies dans le parcours nosgestesclimat.
   Explorez nos modèles: Explorez nos modèles
   Explorez notre documentation: Explorez notre documentation
   Faire le test: Faire le test
@@ -112,6 +107,7 @@ entries:
   Fermer la notification de nouveautés: Fermer la notification de nouveautés
   Fermer les options de tri: Fermer les options de tri
   Fréquence: Fréquence
+  Groupe: Groupe
   Guidé: Guidé
   Initialisation...: Initialisation...
   Insérer cette suggestion: Insérer cette suggestion
@@ -124,17 +120,11 @@ entries:
   La voiture en chiffres: La voiture en chiffres
   Label: Label
   Label (facultatif): Label (facultatif)
-  "Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul.
-    Parmi elles, {numberOfQuestions} règles sont des questions à poser à
-    l'utilisateur pour calculer un résultat précis.
-  "Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi
-    elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur
-    pour calculer un résultat précis.
+  "Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": Le modèle comprend aujourd'hui <1>{numberOfRules}</1> règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.
+  "Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.": Le modèle comprend aujourd'hui {numberOfRules} règles de calcul. Parmi elles, {numberOfQuestions} règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.
   Le modèle d'empreinte carbone de référence: Le modèle d'empreinte carbone de référence
   'Le reste : ': 'Le reste : '
-  "Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.": Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même
-    nom, composé d'un ensemble de briques. Sur cette documentation, vous avez
-    accès en toute transparence à l'ensemble des variables du calcul.
+  "Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.": Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.
   Le test: Le test
   Le titre bref de votre problème: Le titre bref de votre problème
   'Les 3 actions au plus fort impact pour vous :': 'Les 3 actions au plus fort impact pour vous :'
@@ -197,6 +187,7 @@ entries:
   Pour aller plus loin: Pour aller plus loin
   'Pour en savoir plus, tout est expliqué dans ': 'Pour en savoir plus, tout est expliqué dans '
   Problème de traduction: Problème de traduction
+  Profil: Profil
   Progression dans les diapo: Progression dans les diapo
   Précédent: Précédent
   Prêt à démarrer ?: Prêt à démarrer ?
@@ -267,54 +258,22 @@ entries:
   cet article: cet article
   cette page: cette page
   components.NewsBanner.miseAJourDate: Dernière mise à jour {{date}}
-  components.ScoreExplanation.text.p1: 🧮 Voici votre score de départ, calculé à
-    partir de réponses attribuées à l'avance à chaque question ! Il évoluera à
-    chaque nouvelle réponse.
+  components.ScoreExplanation.text.p1: 🧮 Voici votre score de départ, calculé à partir de réponses attribuées à l'avance à chaque question ! Il évoluera à chaque nouvelle réponse.
   components.ScoreExplanation.text.p2: 🧮 Voici votre score provisoire, il évolue à chaque nouvelle réponse !
-  components.ScoreExplanation.text.p3: '🤔 Si vous répondez "je ne sais pas" à une
-    question, le score ne changera pas : une valeur par défaut vous est
-    attribuée.'
+  components.ScoreExplanation.text.p3: '🤔 Si vous répondez "je ne sais pas" à une question, le score ne changera pas : une valeur par défaut vous est attribuée.'
   components.ScoreExplanation.text.p4: 💡 Nous améliorons le calcul et ses valeurs par défaut<1>tous les mois</1>!
-  components.TranslationAlertBanner.wikiLink: La traduction de cette page est en
-    version <1>beta</1>. <4>Un problème, une suggestion ?</4>
-  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne: Vous parcourez {{kmParcouru}} km avec en moyenne {{nbPersonnes}} personnes
-    dans la voiture.
+  components.TranslationAlertBanner.wikiLink: La traduction de cette page est en version <1>beta</1>. <4>Un problème, une suggestion ?</4>
+  components.conversation.estimate.KmHelp.resultatKmParcouruMoyenne: Vous parcourez {{kmParcouru}} km avec en moyenne {{nbPersonnes}} personnes dans la voiture.
   components.conversation.select.NumberedMosaic.choixAFaire: ' Il vous reste {{nbChoix}} choix à faire.'
   components.conversation.select.NumberedMosaic.choixEnTrop: Vous avez fait {{nbChoix}} choix en trop !
-  components.localisation.Localisation.warnMessage: Pour le moment, il n'existe
-    pas de modèle de calcul pour {{countryName}}, le modèle Français vous est
-    proposé par défaut.
-  components.localisation.Localisation.warnMessage2: Nous n'avons pas pu détecter
-    votre pays de simulation, le modèle Français vous est proposé par défaut.
+  components.localisation.Localisation.warnMessage: Pour le moment, il n'existe pas de modèle de calcul pour {{countryName}}, le modèle Français vous est proposé par défaut.
+  components.localisation.Localisation.warnMessage2: Nous n'avons pas pu détecter votre pays de simulation, le modèle Français vous est proposé par défaut.
   components.localisation.LocalisationMessage.betaMsg: Elle est actuellement en version <1>bêta</1>.
   components.localisation.LocalisationMessage.version: Vous utilisez la version <1>{{versionName}}</1> du test.
-  components.localisation.LocalisationMessage.warnMessage: Votre région n'est pas
-    encore supportée, le modèle Français vous est proposé par défaut.
-  components.stats.StatsContent.dureeDesVisites: <0>En savoir plus</0><1>Cette
-    section est générée à partir des visites des 60 derniers jours. Les visites
-    dont le temps passé sur le site est inférieur à 1 minute ont été écartées.
-    Pour éviter le biais de l'iframe qui peut générer des visiteurs inactifs
-    dans les statistiques, le temps moyen sur le site a été calculé à partir des
-    visites actives (l'utilisateur a cliqué sur "Faire le test").</1>
-  components.stats.StatsContent.integrationEtIframes: <0>En savoir plus</0><1>Les
-    intégrations en iframe sont détéctées via le paramètre 'iframe' dans l'URL,
-    ceci seulement si l'intégrateur a utilisé le <2>script dédié</2>. Ainsi, les
-    visites via les iframes d'intégrateurs qui n'ont pas utilisé ce script sont
-    dispersées dans les visites générales de Nos Gestes Climat. Dans l'attente
-    de chiffres plus précis, ce taux est donc potentiellement sous-estimé par
-    rapport à la réalité. <5>(Données valables pour les 30 derniers
-    jours)</5></1>
-  components.stats.StatsContent.scoreUtilisateurs: "<0>En savoir plus</0><1>Bien
-    sûr, nous ne collectons pas <2>les données utlisateurs</2>. Néanmoins, le
-    score total ainsi que l'empreinte par catégorie est présente dans l'URL de
-    fin de test. Dans cette section, nous agrégeons cees informations pour avoir
-    une idée de l'empreinte carbone moyenne de nos utilisateurs et de
-    distribution du score afin d'analyser ces résultats dans le contexte des
-    évolutions du modèle.</1> <3>L'objectif ici n'est pas d'évaluer l'empreinte
-    carbone des Français : à priori, les utilisateurs du tests de sont pas
-    représentatifs des Français. De plus, ces données peuvent être biaisées par
-    des utilisateurs qui reviendraient à plusieurs reprises sur la page de fin,
-    en changeant ses réponses au test (ce qui crée de nouveaux url de fin).</3>"
+  components.localisation.LocalisationMessage.warnMessage: Votre région n'est pas encore supportée, le modèle Français vous est proposé par défaut.
+  components.stats.StatsContent.dureeDesVisites: <0>En savoir plus</0><1>Cette section est générée à partir des visites des 60 derniers jours. Les visites dont le temps passé sur le site est inférieur à 1 minute ont été écartées. Pour éviter le biais de l'iframe qui peut générer des visiteurs inactifs dans les statistiques, le temps moyen sur le site a été calculé à partir des visites actives (l'utilisateur a cliqué sur "Faire le test").</1>
+  components.stats.StatsContent.integrationEtIframes: <0>En savoir plus</0><1>Les intégrations en iframe sont détéctées via le paramètre 'iframe' dans l'URL, ceci seulement si l'intégrateur a utilisé le <2>script dédié</2>. Ainsi, les visites via les iframes d'intégrateurs qui n'ont pas utilisé ce script sont dispersées dans les visites générales de Nos Gestes Climat. Dans l'attente de chiffres plus précis, ce taux est donc potentiellement sous-estimé par rapport à la réalité. <5>(Données valables pour les 30 derniers jours)</5></1>
+  components.stats.StatsContent.scoreUtilisateurs: "<0>En savoir plus</0><1>Bien sûr, nous ne collectons pas <2>les données utlisateurs</2>. Néanmoins, le score total ainsi que l'empreinte par catégorie est présente dans l'URL de fin de test. Dans cette section, nous agrégeons cees informations pour avoir une idée de l'empreinte carbone moyenne de nos utilisateurs et de distribution du score afin d'analyser ces résultats dans le contexte des évolutions du modèle.</1> <3>L'objectif ici n'est pas d'évaluer l'empreinte carbone des Français : à priori, les utilisateurs du tests de sont pas représentatifs des Français. De plus, ces données peuvent être biaisées par des utilisateurs qui reviendraient à plusieurs reprises sur la page de fin, en changeant ses réponses au test (ce qui crée de nouveaux url de fin).</3>"
   de CO₂e en moyenne: de CO₂e en moyenne
   de visites ce mois ci<1>&nbsp;(par rapport au mois d'avant)</1>: de visites ce mois ci<1>&nbsp;(par rapport au mois d'avant)</1>
   derniers: derniers
@@ -325,13 +284,10 @@ entries:
   en moyenne sur le site: en moyenne sur le site
   et: et
   et visualisez les résultats du groupe: et visualisez les résultats du groupe
-  feedback.bad.form.headline: Votre retour nous est précieux afin d'améliorer ce
-    site en continu. Sur quoi devrions nous travailler afin de mieux répondre à
-    vos attentes ?
+  feedback.bad.form.headline: Votre retour nous est précieux afin d'améliorer ce site en continu. Sur quoi devrions nous travailler afin de mieux répondre à vos attentes ?
   feedback.question: Cette page vous est utile ?
   feedback.reportError: Faire une suggestion
-  feedback.thanks: Merci pour votre retour ! Vous pouvez nous contacter
-    directement à <2>contact@mon-entreprise.beta.gouv.fr</2>
+  feedback.thanks: Merci pour votre retour ! Vous pouvez nous contacter directement à <2>contact@mon-entreprise.beta.gouv.fr</2>
   fois par: fois par
   habitant: habitant
   habitants: habitants
@@ -342,90 +298,38 @@ entries:
   le + d'impact climat: le + d'impact climat
   le - d'impact climat: le - d'impact climat
   meta.pages.actions.description: Découvrez les gestes qui veous permettent de réduire votre empreinte climat
-  meta.publicodes.About.description: Ce simulateur vous permet d'évaluer votre
-    empreinte carbone individuelle annuelle totale et par grandes catégories
-    (alimentation, transport, logement, divers, services publics, numérique), de
-    la situer par rapport aux objectifs climatiques et surtout de passer à
-    l’action à votre niveau avec des gestes personnalisés en fonction de vos
-    réponses.
+  meta.publicodes.About.description: Ce simulateur vous permet d'évaluer votre empreinte carbone individuelle annuelle totale et par grandes catégories (alimentation, transport, logement, divers, services publics, numérique), de la situer par rapport aux objectifs climatiques et surtout de passer à l’action à votre niveau avec des gestes personnalisés en fonction de vos réponses.
   meta.publicodes.About.title: À propos
-  meta.publicodes.Accessibility.description: Le site Nos Gestes Climat est
-    partiellement conforme avec le référentiel général d’amélioration de
-    l’accessibilité, RGAA version 4.1
+  meta.publicodes.Accessibility.description: Le site Nos Gestes Climat est partiellement conforme avec le référentiel général d’amélioration de l’accessibilité, RGAA version 4.1
   meta.publicodes.Accessibility.title: Accessibilité
-  meta.publicodes.CGU.description: Les présentes conditions générales
-    d'utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme
-    "Nos Gestes Climat" et définissent les conditions d'accès et d'utilisation
-    des services par l'Utilisateur.
+  meta.publicodes.CGU.description: Les présentes conditions générales d'utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme "Nos Gestes Climat" et définissent les conditions d'accès et d'utilisation des services par l'Utilisateur.
   meta.publicodes.CGU.title: Conditions générales d'utilisation
-  meta.publicodes.Contribution.description: Découvrez les questions fréquentes sur
-    Nos Gestes Climat, et comment en poser de nouvelles ou nous aider.
-  meta.publicodes.Diffuser.description: Ce simulateur vous permet d'évaluer votre
-    empreinte carbone individuelle annuelle totale et par grandes catégories
-    (alimentation, transport, logement, divers, services publics, numérique), de
-    la situer par rapport aux objectifs climatiques et surtout de passer à
-    l’action à votre niveau avec des gestes personnalisés en fonction de vos
-    réponses.
+  meta.publicodes.Contribution.description: Découvrez les questions fréquentes sur Nos Gestes Climat, et comment en poser de nouvelles ou nous aider.
+  meta.publicodes.Diffuser.description: Ce simulateur vous permet d'évaluer votre empreinte carbone individuelle annuelle totale et par grandes catégories (alimentation, transport, logement, divers, services publics, numérique), de la situer par rapport aux objectifs climatiques et surtout de passer à l’action à votre niveau avec des gestes personnalisés en fonction de vos réponses.
   meta.publicodes.Diffuser.title: Diffuser Nos Gestes Climat
-  meta.publicodes.Landing.description: Testez votre empreinte carbone, tout seul
-    ou en groupe. Découvrez la répartition de votre empreinte. Suivez le
-    parcours de passage à l'action pour la réduire.
-  meta.publicodes.LandingExplanations.description: Testez votre empreinte carbone,
-    tout seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez
-    le parcours de passage à l'action pour la réduire.
-  meta.publicodes.Méthode.description: Notre modèle de calcul est entièrement
-    transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
+  meta.publicodes.Landing.description: Testez votre empreinte carbone, tout seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez le parcours de passage à l'action pour la réduire.
+  meta.publicodes.LandingExplanations.description: Testez votre empreinte carbone, tout seul ou en groupe. Découvrez la répartition de votre empreinte. Suivez le parcours de passage à l'action pour la réduire.
+  meta.publicodes.Méthode.description: Notre modèle de calcul est entièrement transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
   meta.publicodes.Méthode.title: Comprendre nos calculs
-  meta.publicodes.PetrogazLanding.description: Nos Gestes Climat vous permet non
-    seulement d'estimer votre empreinte sur le climat, mais également votre
-    consommation de pétrole. Ce dernier est responsable d'une grande partie de
-    l'empreinte climat, mais son achat a également d'autres conséquences,
-    notamment géopolitiques.
+  meta.publicodes.PetrogazLanding.description: Nos Gestes Climat vous permet non seulement d'estimer votre empreinte sur le climat, mais également votre consommation de pétrole. Ce dernier est responsable d'une grande partie de l'empreinte climat, mais son achat a également d'autres conséquences, notamment géopolitiques.
   meta.publicodes.PetrogazLanding.title: Mon empreinte pétrole et gaz
-  meta.publicodes.Privacy.description: Nos gestes climat, hors mode groupe,
-    fonctionne sans serveur, donc vos données restent chez vous. Nous collectons
-    anonymement des données aggregées pour améliorer le simulateur.
+  meta.publicodes.Privacy.description: Nos gestes climat, hors mode groupe, fonctionne sans serveur, donc vos données restent chez vous. Nous collectons anonymement des données aggregées pour améliorer le simulateur.
   meta.publicodes.Privacy.title: Données personnelles
-  meta.publicodes.fin.Budget.description: Mon empreinte climat est de
-    {{roundedValue}} tonnes de CO2e. Mesure la tienne !
-  meta.publicodes.fin.Petrogaz.description: Mon empreinte pétrole est de
-    {{empreinte}} pleins de pétrole. Mesure la tienne !
-  meta.publicodes.fin.actionslide.description: Le top 3 des actions pour réduire
-    mon empreinte climat de {{roundedValue}} tonnes de CO₂ₑ.
-  meta.publicodes.pages.Documentation.description: Notre modèle de calcul est
-    entièrement transparent. Chacun peut l'explorer, donner son avis,
-    l'améliorer.
-  meta.publicodes.pages.Documentation.intro: Le simulateur Nos Gestes Climat est
-    basé sur le modèle de calcul du même nom, composé d'un ensemble de briques.
-    Sur cette documentation, vous avez accès en toute transparence à l'ensemble
-    des variables du calcul.
+  meta.publicodes.fin.Budget.description: Mon empreinte climat est de {{roundedValue}} tonnes de CO2e. Mesure la tienne !
+  meta.publicodes.fin.Petrogaz.description: Mon empreinte pétrole est de {{empreinte}} pleins de pétrole. Mesure la tienne !
+  meta.publicodes.fin.actionslide.description: Le top 3 des actions pour réduire mon empreinte climat de {{roundedValue}} tonnes de CO₂ₑ.
+  meta.publicodes.pages.Documentation.description: Notre modèle de calcul est entièrement transparent. Chacun peut l'explorer, donner son avis, l'améliorer.
+  meta.publicodes.pages.Documentation.intro: Le simulateur Nos Gestes Climat est basé sur le modèle de calcul du même nom, composé d'un ensemble de briques. Sur cette documentation, vous avez accès en toute transparence à l'ensemble des variables du calcul.
   minutes: minutes
-  model.active: Voici à titre d'exemple quelques <1>issues</1> importantes du
-    moment parmi la centaine de sujets documentés.
-  model.intro: Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte
-    climat individuelle de consommation de référence.
-  model.intro2: Entièrement ouvert (open source) et contributif, chacun peut
-    l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>.
-  model.modern: Le modèle est basé sur <1>publicodes</1>, un langage conçu par
-    l'État pour exprimer des algorithmes d'intérêt public.
-  model.modern2: Entièrement paramétrable, depuis les questions posées à
-    l'utilisateur jusqu'aux hypothèses du modèle de calcul, il peut être
-    réutilisé <2>librement</2> par tout type d'acteur.
-  model.modern3: ⬇️ Ci-dessous, vous pouvez voir l'influence de 3 paramètres de
-    calcul sur les résultats finaux.
-  model.modern4: Le modèle de calcul est directement embarqué chez le client, le
-    calcul a lieu là dans votre navigateur, pas sur nos serveurs. Les données
-    collectées sont si descriptives de la vie des utilisateurs, donc sensibles
-    en termes de vie privée, que faire les calculs côté serveur <2>et les
-    stocker</2> poserait un risque trop élevé.
-  model.stats: Le modèle comprend aujourd'hui <1></1> règles de calcul. Parmi
-    elles, <3></3> règles sont des questions à poser à l'utilisateur pour
-    calculer un résultat précis.
-  model.stats2: Il est constitué d'une combinaison de centaines de modèles micro
-    "bottom-up" pour les consommations carbonées de notre vie quotidienne, et
-    d'un modèle "top-down" dérivé des travaux du SDES pour estimer l'empreinte
-    par personne des services dits sociétaux (services publics et services de
-    base tels les télécom). <2>En savoir plus sur cette hybridation</2>.
+  model.active: Voici à titre d'exemple quelques <1>issues</1> importantes du moment parmi la centaine de sujets documentés.
+  model.intro: Derrière le site nosgestesclimat.fr, se cache le modèle d'empreinte climat individuelle de consommation de référence.
+  model.intro2: Entièrement ouvert (open source) et contributif, chacun peut l'<1>explorer</1>, <4>donner son avis</4>, <7>l'améliorer</7>.
+  model.modern: Le modèle est basé sur <1>publicodes</1>, un langage conçu par l'État pour exprimer des algorithmes d'intérêt public.
+  model.modern2: Entièrement paramétrable, depuis les questions posées à l'utilisateur jusqu'aux hypothèses du modèle de calcul, il peut être réutilisé <2>librement</2> par tout type d'acteur.
+  model.modern3: ⬇️ Ci-dessous, vous pouvez voir l'influence de 3 paramètres de calcul sur les résultats finaux.
+  model.modern4: Le modèle de calcul est directement embarqué chez le client, le calcul a lieu là dans votre navigateur, pas sur nos serveurs. Les données collectées sont si descriptives de la vie des utilisateurs, donc sensibles en termes de vie privée, que faire les calculs côté serveur <2>et les stocker</2> poserait un risque trop élevé.
+  model.stats: Le modèle comprend aujourd'hui <1></1> règles de calcul. Parmi elles, <3></3> règles sont des questions à poser à l'utilisateur pour calculer un résultat précis.
+  model.stats2: Il est constitué d'une combinaison de centaines de modèles micro "bottom-up" pour les consommations carbonées de notre vie quotidienne, et d'un modèle "top-down" dérivé des travaux du SDES pour estimer l'empreinte par personne des services dits sociétaux (services publics et services de base tels les télécom). <2>En savoir plus sur cette hybridation</2>.
   mois: mois
   mon empreinte annuelle: mon empreinte annuelle
   mon objectif: mon objectif
@@ -434,8 +338,7 @@ entries:
   ont utilisé l'aide à la saisie des km: ont utilisé l'aide à la saisie des km
   ou: ou
   pages.News.determinant: of
-  pages.News.premierParagraphe: Nous améliorons le site en continu à partir de vos
-    retours. Découvrez ici les dernières nouveautés.
+  pages.News.premierParagraphe: Nous améliorons le site en continu à partir de vos retours. Découvrez ici les dernières nouveautés.
   participant: participant
   pleins: pleins
   pleins de pétrole: pleins de pétrole
@@ -445,193 +348,75 @@ entries:
   plus de 10 tonnes: plus de 10 tonnes
   plus de 100 kg: plus de 100 kg
   publicodes.ActionTutorial.félicitation: Vous avez terminé votre simulation, 👏 bravo !
-  publicodes.ActionTutorial.msgEstimation: Vous connaissez maintenant votre
-    empreinte, estimée à {{value}} {{unit}}, et vous avez sûrement déjà des
-    idées pour la réduire...
-  publicodes.ActionTutorial.msgPrécision: 💡 Pour améliorer la précision,
-    certaines actions vous poseront quelques questions en plus.
+  publicodes.ActionTutorial.msgEstimation: Vous connaissez maintenant votre empreinte, estimée à {{value}} {{unit}}, et vous avez sûrement déjà des idées pour la réduire...
+  publicodes.ActionTutorial.msgPrécision: 💡 Pour améliorer la précision, certaines actions vous poseront quelques questions en plus.
   publicodes.ActionTutorial.msgPrésentation: "Pour vous aider, nous vous présenterons <2>une liste d'actions</2> :"
   publicodes.ActionVignette.questionsRestantesText: '{{nbRemainingQuestions}} question{{pluralSuffix}} restante{{pluralSuffix}}'
   publicodes.ActionsOptionsBar.actionsRecap: '{{numberOfAvailableFinalActions}} actions disponibles,'
-  publicodes.AllActions.allerPlusLoin: <0>Aller plus loin</0><1><0>Au-delà d'un
-    simple chiffre, découvrez les enjeux qui se cachent derrière chaque
-    action.</0></1>
-  publicodes.AllActions.msgPlusActions: <0>Nous n'avons plus d'actions chiffrées
-    très impactantes à vous proposer 🤷</0><1>Découvrez plus bas quelques pistes
-    pour agir autrement ⏬</1>
+  publicodes.AllActions.allerPlusLoin: <0>Aller plus loin</0><1><0>Au-delà d'un simple chiffre, découvrez les enjeux qui se cachent derrière chaque action.</0></1>
+  publicodes.AllActions.msgPlusActions: <0>Nous n'avons plus d'actions chiffrées très impactantes à vous proposer 🤷</0><1>Découvrez plus bas quelques pistes pour agir autrement ⏬</1>
   publicodes.Contribution.bugQuestion: 🐛 Vous avez un bug qui vous empêche d'utiliser Nos Gestes Climat ?
   publicodes.Contribution.commentaireAugmenté: |-
 
     > Ce ticket a été créé automatiquement par notre robot depuis notre [page de contribution](https://nosgestesclimat.fr/contribuer).
-  publicodes.Contribution.description: Vous trouverez ici les réponses aux
-    questions les plus fréquentes. S’il vous reste des interrogations ou si vous
-    souhaitez nous proposer des améliorations, rendez-vous tout en bas. Bonne
-    lecture !
-  publicodes.Contribution.descriptionComplète: <0>La description complète de votre
-    problème</0><1><0>En indiquant le navigateur que vous utilisez (par exemple
-    Firefox version 93, Chrome version 95, Safari, etc.), et la plateforme
-    (iPhone, Android, ordinateur Windows, etc.), vous nous aiderez à résoudre le
-    bug plus rapidement.</0></1>
+  publicodes.Contribution.description: Vous trouverez ici les réponses aux questions les plus fréquentes. S’il vous reste des interrogations ou si vous souhaitez nous proposer des améliorations, rendez-vous tout en bas. Bonne lecture !
+  publicodes.Contribution.descriptionComplète: <0>La description complète de votre problème</0><1><0>En indiquant le navigateur que vous utilisez (par exemple Firefox version 93, Chrome version 95, Safari, etc.), et la plateforme (iPhone, Android, ordinateur Windows, etc.), vous nous aiderez à résoudre le bug plus rapidement.</0></1>
   publicodes.Contribution.descriptionComplèteTraduction: <0>La description complète de votre problème</0>
-  publicodes.Contribution.liensVersGithub: Pour toute remarque ou question, nous
-    vous invitons à <2>ouvrir un ticket directement sur GitHub</2>.
-  publicodes.Contribution.remerciements: Merci 😍! Suivez l'avancement de votre
-    suggestion en cliquant sur <1>ce lien</1>.
+  publicodes.Contribution.liensVersGithub: Pour toute remarque ou question, nous vous invitons à <2>ouvrir un ticket directement sur GitHub</2>.
+  publicodes.Contribution.remerciements: Merci 😍! Suivez l'avancement de votre suggestion en cliquant sur <1>ce lien</1>.
   publicodes.Contribution.titreQuestion: J'ai une autre question
-  publicodes.Contribution.traductionIntro: Nos Gestes Climat vient tout juste
-    d'être traduit dans plusieurs langues. N'hésitez pas à vous faire part de
-    vos doutes quand à un problèm de traduction sur le site 😊. Nous le
-    prendrons en compte rapidement.
-  publicodes.Contribution.translationWikiInvite: 'Suivez notre guide complet pour
-    contribuer directement à la traduction du site : <2>rendez-vous sur notre
-    wiki</2>.'
+  publicodes.Contribution.traductionIntro: Nos Gestes Climat vient tout juste d'être traduit dans plusieurs langues. N'hésitez pas à vous faire part de vos doutes quand à un problèm de traduction sur le site 😊. Nous le prendrons en compte rapidement.
+  publicodes.Contribution.translationWikiInvite: 'Suivez notre guide complet pour contribuer directement à la traduction du site : <2>rendez-vous sur notre wiki</2>.'
   publicodes.Landing.question: Connaissez-vous votre empreinte sur le climat ?
   publicodes.LandingExplanations.question: Connaissez-vous votre empreinte sur le climat ?
-  publicodes.Personas.description: Les personas nous permettront de prendre le
-    parti d'une diversité d'utilisateurs quand ils voient notamment notre écran
-    "passer à l'action".
+  publicodes.Personas.description: Les personas nous permettront de prendre le parti d'une diversité d'utilisateurs quand ils voient notamment notre écran "passer à l'action".
   publicodes.Personas.lienGenerateur: Pour les prénoms, on peut utiliser <2>ce générateur</2>
-  publicodes.Personas.tuto: que ça se passe. On peut soit copier coller les
-    données d'un autre persona et les modifier, soit en créer un de zéro depuis
-    la simulation. Une fois la simulation satisfaisante, cliquer sur "Modifier
-    mes réponses" puis taper Ctrl-C, ouvrir la console du navigateur (F12),
-    vérifiez bien que vous êtes dans l'onglet "Console", allez tout en bas de la
-    console (elle est un peu chargée...), puis copier le JSON affiché, le coller
-    dans <2>cet outil</2> pour générer un YAML, puis l'insérer dans
-    personas.yaml.
-  publicodes.Personas.warningMsg: 'Attention, vous avez une simulation en cours :
-    sélectionner un persona écrasera votre simulation.'
-  publicodes.Profil.locationDonnées: <0>Où sont mes données ? </0>Vos données sont
-    stockées dans votre navigateur, vous avez donc le contrôle total sur elles.
-    <2></2>
-  publicodes.Profil.recap: Vous avez terminé le test à {{percentFinished}} %
-    ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}}
-    actions.
-  publicodes.SimulationMissing.personnas: 💡 Vous pouvez aussi voir le parcours
-    action comme si vous étiez l'un de ces profils types.
-  publicodes.SimulationMissing.simulationManquante: Vous n'avez pas encore fait le
-    test. Pour débloquer ce parcours, vous devez nous en dire un peu plus sur
-    votre mode de vie.
+  publicodes.Personas.tuto: que ça se passe. On peut soit copier coller les données d'un autre persona et les modifier, soit en créer un de zéro depuis la simulation. Une fois la simulation satisfaisante, cliquer sur "Modifier mes réponses" puis taper Ctrl-C, ouvrir la console du navigateur (F12), vérifiez bien que vous êtes dans l'onglet "Console", allez tout en bas de la console (elle est un peu chargée...), puis copier le JSON affiché, le coller dans <2>cet outil</2> pour générer un YAML, puis l'insérer dans personas.yaml.
+  publicodes.Personas.warningMsg: 'Attention, vous avez une simulation en cours : sélectionner un persona écrasera votre simulation.'
+  publicodes.Profil.locationDonnées: <0>Où sont mes données ? </0>Vos données sont stockées dans votre navigateur, vous avez donc le contrôle total sur elles. <2></2>
+  publicodes.Profil.recap: Vous avez terminé le test à {{percentFinished}} % ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}} actions.
+  publicodes.SimulationMissing.personnas: 💡 Vous pouvez aussi voir le parcours action comme si vous étiez l'un de ces profils types.
+  publicodes.SimulationMissing.simulationManquante: Vous n'avez pas encore fait le test. Pour débloquer ce parcours, vous devez nous en dire un peu plus sur votre mode de vie.
   publicodes.TranslationContribution.commentaireAugmenté: |-
 
     > Ce ticket a été créé automatiquement par notre robot depuis notre [page de contribution pour la traduction](https://nosgestesclimat.fr/contribuer-traduction).
-  publicodes.TranslationContribution.remerciements: Merci 😍! Suivez l'avancement
-    de votre suggestion en cliquant sur <2>ce lien</2>.
-  publicodes.Tutorial.slide1.p1: <0>Pas de panique, on vous explique ce que
-    c'est.</0><1>La planète <1>se réchauffe dangereusement</1>, au fur et à
-    mesure des gaz à effet de serre que l'on émet.</1>
-  publicodes.Tutorial.slide1.p2: <0>Ce test vous donne en ⏱️ 10 minutes chrono
-    <2>une mesure de votre part </2> dans ce réchauffement.</0>
-  publicodes.Tutorial.slide2.blockquote: "D'autres gaz, surtout le méthane <2></2>
-    et le protoxyde d'azote <6></6> réchauffent aussi la planète : on convertit
-    leur potentiel de réchauffement en équivalent CO₂ pour simplifier la mesure.
-    "
-  publicodes.Tutorial.slide2.p1: "Avec une unité au nom barbare : l'équivalent
-    CO₂. Le dioxyde de carbone<1></1>, vous le connaissez : on l'expire toute la
-    journée, mais sans influence sur le climat."
-  publicodes.Tutorial.slide2.p2: Ce sont les machines qui font notre confort
-    moderne qui en rejettent massivement, à tel point qu'on le compte en
-    milliers de kilos par an et par personne, donc en <1>tonnes</1> de CO₂e !
-  publicodes.Tutorial.slide5.p1: <0>Et l'objectif ?</0><1>Nous devons diminuer
-    notre empreinte climat au plus vite.</1><2>En France, ça consiste à passer
-    de ~10 tonnes à <2>moins de 2 tonnes</2> par an.</2>
-  publicodes.Tutorial.slide6: <0>D'où vient notre empreinte ?</0><1>Prendre la
-    voiture, manger un steak, chauffer sa maison, se faire soigner, acheter une
-    TV...</1><2><0><0></0></0></2><3>L'empreinte de notre consommation
-    individuelle, c'est la somme de toutes ces activités qui font notre vie
-    moderne. </3>
-  publicodes.Tutorial.slide7: "<0>Alors, c'est parti ?</0><1>Quelques astuces pour
-    vous aider à compléter le test :</1><2>👤 Répondez aux questions en votre
-    nom, pas au nom de votre foyer : c'est un test individuel.</2><3>💼 Répondez
-    pour votre vie perso, pas pour votre boulot ou études. <2>Une seule
-    exception </2>: votre trajet domicile-travail doit être inclus dans les km
-    parcourus.</3><4>❓️ D'autres questions ? Consultez notre <2>FAQ</2> à tout
-    moment.</4>"
+  publicodes.TranslationContribution.remerciements: Merci 😍! Suivez l'avancement de votre suggestion en cliquant sur <2>ce lien</2>.
+  publicodes.Tutorial.slide1.p1: <0>Pas de panique, on vous explique ce que c'est.</0><1>La planète <1>se réchauffe dangereusement</1>, au fur et à mesure des gaz à effet de serre que l'on émet.</1>
+  publicodes.Tutorial.slide1.p2: <0>Ce test vous donne en ⏱️ 10 minutes chrono <2>une mesure de votre part </2> dans ce réchauffement.</0>
+  publicodes.Tutorial.slide2.blockquote: "D'autres gaz, surtout le méthane <2></2> et le protoxyde d'azote <6></6> réchauffent aussi la planète : on convertit leur potentiel de réchauffement en équivalent CO₂ pour simplifier la mesure. "
+  publicodes.Tutorial.slide2.p1: "Avec une unité au nom barbare : l'équivalent CO₂. Le dioxyde de carbone<1></1>, vous le connaissez : on l'expire toute la journée, mais sans influence sur le climat."
+  publicodes.Tutorial.slide2.p2: Ce sont les machines qui font notre confort moderne qui en rejettent massivement, à tel point qu'on le compte en milliers de kilos par an et par personne, donc en <1>tonnes</1> de CO₂e !
+  publicodes.Tutorial.slide5.p1: <0>Et l'objectif ?</0><1>Nous devons diminuer notre empreinte climat au plus vite.</1><2>En France, ça consiste à passer de ~10 tonnes à <2>moins de 2 tonnes</2> par an.</2>
+  publicodes.Tutorial.slide6: <0>D'où vient notre empreinte ?</0><1>Prendre la voiture, manger un steak, chauffer sa maison, se faire soigner, acheter une TV...</1><2><0><0></0></0></2><3>L'empreinte de notre consommation individuelle, c'est la somme de toutes ces activités qui font notre vie moderne. </3>
+  publicodes.Tutorial.slide7: "<0>Alors, c'est parti ?</0><1>Quelques astuces pour vous aider à compléter le test :</1><2>👤 Répondez aux questions en votre nom, pas au nom de votre foyer : c'est un test individuel.</2><3>💼 Répondez pour votre vie perso, pas pour votre boulot ou études. <2>Une seule exception </2>: votre trajet domicile-travail doit être inclus dans les km parcourus.</3><4>❓️ D'autres questions ? Consultez notre <2>FAQ</2> à tout moment.</4>"
   publicodes.chart.GridChart.equivalenceCase: Une case 🔲 = {{nbKg}} kg de CO₂e.
-  publicodes.conference.Conference.donnéesExplications: "<0>En participant, vous
-    acceptez de partager vos résultats agrégés de simulation avec les autres
-    participants de la conférence : le total et les catégories (transport,
-    logement, etc.). En revanche, nos serveurs ne les stockent pas : cela
-    fonctionne en P2P (pair à pair).</0><1>Seul le nom de la salle de conférence
-    sera indexé dans <2>les statistiques d'utilisation</2> de Nos Gestes Climat.
-    </1>"
-  publicodes.conference.DataWarning.explanation: 'Le principe est simple : chacun
-    fait son test sur son appareil, et les résultats sont mis en commun en temps
-    réel avec les autres participants du sondage.'
-  publicodes.conference.DataWarning.viePrivée: "🕵 En participant, vous acceptez
-    la collecte <1>anonyme</1> de vos résultats agrégés de simulation sur notre
-    serveur : l'empreinte climat totale et les catégories (transport, logement,
-    etc.). <3>En savoir plus</3>"
-  publicodes.conference.Instructions.avertissementModeConference: "<0>Attention</0>, il est possible que votre organisation bloque le
-    pair-à-pair, et donc l'utilisation du mode conférence. Faites le test au
-    préalable sur site et en duo : en cas de problème, vous pouvez utiliser le
-    mode sondage."
-  publicodes.conference.Instructions.contextualisationLink: 💡 Vous souhaitez
-    ajouter des questions pour obtenir des informations supplémentaires sur les
-    répondants ? <2>Découvrez la fonctionnalité "contextualisation de sondage !"
-    </2>
-  publicodes.conference.Instructions.descriptionModeConference: "Mode éphémère : parfait pour l'animation d'un atelier, une présentation
-    interactive ou entre amis. Les données restent entre les participants
-    (pair-à-pair sans serveur), <2>juste le temps de la conférence</2>."
-  publicodes.conference.Instructions.descriptionModeSondage: 'Mode persistant :
-    les données des participants sont stockées sur notre serveur et restent
-    accessibles et téléchargeables <2>pendant deux mois</2>.'
-  publicodes.conference.Instructions.guideLien: Les résultats sont là, que faire ?
-    Notre guide vous accompagne dans vos réflexions et vos discussions sur cette
-    page
-  publicodes.conference.Instructions.intro: <0>Le test d'empreinte climat est
-    individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun
-    sera derrière son écran, mais visualisera en temps réel les résultats des
-    autres.</0><1>C'est l'occasion de réfléchir ensemble aux enjeux de notre
-    propre impact en comparant nos modes de vie.</1>
-  publicodes.conference.Instructions.liensSimulationConference: Au moment convenu, ouvrez ce lien tous en même temps et faites chacun de
-    votre côté votre simulation.
+  publicodes.conference.Conference.donnéesExplications: "<0>En participant, vous acceptez de partager vos résultats agrégés de simulation avec les autres participants de la conférence : le total et les catégories (transport, logement, etc.). En revanche, nos serveurs ne les stockent pas : cela fonctionne en P2P (pair à pair).</0><1>Seul le nom de la salle de conférence sera indexé dans <2>les statistiques d'utilisation</2> de Nos Gestes Climat. </1>"
+  publicodes.conference.DataWarning.explanation: 'Le principe est simple : chacun fait son test sur son appareil, et les résultats sont mis en commun en temps réel avec les autres participants du sondage.'
+  publicodes.conference.DataWarning.viePrivée: "🕵 En participant, vous acceptez la collecte <1>anonyme</1> de vos résultats agrégés de simulation sur notre serveur : l'empreinte climat totale et les catégories (transport, logement, etc.). <3>En savoir plus</3>"
+  publicodes.conference.Instructions.avertissementModeConference: "<0>Attention</0>, il est possible que votre organisation bloque le pair-à-pair, et donc l'utilisation du mode conférence. Faites le test au préalable sur site et en duo : en cas de problème, vous pouvez utiliser le mode sondage."
+  publicodes.conference.Instructions.contextualisationLink: 💡 Vous souhaitez ajouter des questions pour obtenir des informations supplémentaires sur les répondants ? <2>Découvrez la fonctionnalité "contextualisation de sondage !" </2>
+  publicodes.conference.Instructions.descriptionModeConference: "Mode éphémère : parfait pour l'animation d'un atelier, une présentation interactive ou entre amis. Les données restent entre les participants (pair-à-pair sans serveur), <2>juste le temps de la conférence</2>."
+  publicodes.conference.Instructions.descriptionModeSondage: 'Mode persistant : les données des participants sont stockées sur notre serveur et restent accessibles et téléchargeables <2>pendant deux mois</2>.'
+  publicodes.conference.Instructions.guideLien: Les résultats sont là, que faire ? Notre guide vous accompagne dans vos réflexions et vos discussions sur cette page
+  publicodes.conference.Instructions.intro: <0>Le test d'empreinte climat est individuel, mais nous vous proposons ici de le faire à plusieurs. Chacun sera derrière son écran, mais pourra voir en temps réel les résultats des autres.</0><1>C'est l'occasion de réfléchir ensemble aux enjeux de notre propre impact en comparant nos modes de vie.</1>
+  publicodes.conference.Instructions.liensSimulationConference: Au moment convenu, ouvrez ce lien tous en même temps et faites chacun de votre côté votre simulation.
   publicodes.conference.Instructions.liensSimulationSondage: Les participants doivent venir faire leur simulation sur ce lien.
-  publicodes.conference.Instructions.resultatInfos: "Les résultats pour chaque
-    catégorie (alimentation, transport, logement ...) s'affichent
-    progressivement et en temps réel pour l'ensemble du groupe sur "
-  publicodes.conference.NamingBlock.nomSalleCourt: ⚠️ Votre nom de salle est
-    court, il y a un petit risque que des inconnus puissent le deviner
-  publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres: 💡 Votre nom de salle ne peut que contenir des lettres, des chiffres et des
-    tirets
-  publicodes.conference.NoTestMessage.bienvenue: Bienvenue dans le mode groupe de
-    Nos Gestes Climat ! Vous n'avez pas encore débuté votre test, lancez-vous !
+  publicodes.conference.Instructions.resultatInfos: "Les résultats pour chaque catégorie (alimentation, transport, logement ...) s'affichent progressivement et en temps réel pour l'ensemble du groupe sur "
+  publicodes.conference.NamingBlock.nomSalleCourt: ⚠️ Votre nom de salle est court, il y a un petit risque que des inconnus puissent le deviner
+  publicodes.conference.NamingBlock.nomSalleDoitContenirDesLettres: 💡 Votre nom de salle ne peut que contenir des lettres, des chiffres et des tirets
+  publicodes.conference.NoTestMessage.bienvenue: Bienvenue dans le mode groupe de Nos Gestes Climat ! Vous n'avez pas encore débuté votre test, lancez-vous !
   publicodes.conference.Survey.csv: Vous pouvez récupérer les résultats du sondage dans le format .csv.
-  publicodes.conference.Survey.excel: 'Pour l''ouvrir avec Microsoft Excel, ouvrez
-    un tableur vide, puis Données > À partir d''un fichier texte / CSV.
-    Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
+  publicodes.conference.Survey.excel: 'Pour l''ouvrir avec Microsoft Excel, ouvrez un tableur vide, puis Données > À partir d''un fichier texte / CSV. Sélectionnez "Origine : Unicode UTF-8" et "Délimiteur : virgule".'
   publicodes.conference.Survey.libreOffice: Pour l'ouvrir avec <2>LibreOffice</2>, c'est automatique.
-  publicodes.conference.Survey.notCreatedWarning1: Attention, il n'existe aucun
-    sondage à cette adresse. Pour lancer un sondage, l'organisateur doit d'abord
-    le créer sur la page du <2>mode groupe</2>.
-  publicodes.conference.Survey.notCreatedWarning2: Peut-être avez-vous fait une
-    faute de frappe dans l'adresse du sondage ? Pensez notamment à bien
-    respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le
-    QR code.
-  publicodes.conference.Survey.resultat: Les résultats de la page de visualisation
-    ne prennent en compte que les participants ayant rempli <1>au moins 10% du
-    test</1>. En revanche le CSV contient les simulations de toutes les
-    personnes ayant participé au sondage en cliquant sur le lien. La colonne
-    "progress" vous permet de filtrer les simulations à votre tour.
-  publicodes.fin.ActionTeaser.félicitations: '{{displayedTotal}} tonnes !<2> Vous
-    êtes très nettement en-dessous de la moyenne française.</2> '
-  publicodes.fin.ActionTeaser.messagePourConvaincre: Il y a de grandes chances que
-    votre temps soit plus efficace à convaincre et aider les autres qu'à
-    chercher à gagner vos "tonnes en trop" (même s'il faudra le faire un jour).
+  publicodes.conference.Survey.notCreatedWarning1: Attention, il n'existe aucun sondage à cette adresse. Pour lancer un sondage, l'organisateur doit d'abord le créer sur la page du <2>mode groupe</2>.
+  publicodes.conference.Survey.notCreatedWarning2: Peut-être avez-vous fait une faute de frappe dans l'adresse du sondage ? Pensez notamment à bien respecter les majuscules, à copier coller l'adresse exacte ou à utiliser le QR code.
+  publicodes.conference.Survey.resultat: Les résultats de la page de visualisation ne prennent en compte que les participants ayant rempli <1>au moins 10% du test</1>. En revanche le CSV contient les simulations de toutes les personnes ayant participé au sondage en cliquant sur le lien. La colonne "progress" vous permet de filtrer les simulations à votre tour.
+  publicodes.fin.ActionTeaser.félicitations: '{{displayedTotal}} tonnes !<2> Vous êtes très nettement en-dessous de la moyenne française.</2> '
+  publicodes.fin.ActionTeaser.messagePourConvaincre: Il y a de grandes chances que votre temps soit plus efficace à convaincre et aider les autres qu'à chercher à gagner vos "tonnes en trop" (même s'il faudra le faire un jour).
   publicodes.fin.IframeDataShareModal.partageResultats: Partage de vos résultats à {{parent}} ?
-  publicodes.fin.IframeDataShareModal.text: <0>En cliquant sur le bouton Accepter,
-    vous autorisez {{parent}} à récupérer le bilan de votre empreinte
-    climat.</0><1>Il s'agit de vos résultats sur les grandes catégories
-    (transport, alimentation...), mais <1>pas</1> le détail question par
-    question (vos km en voiture, les m² de votre
-    logement...).</1><2>Nosgestesclimat.fr n'est pas affilié au site
-    {{parent}}.</2>
+  publicodes.fin.IframeDataShareModal.text: <0>En cliquant sur le bouton Accepter, vous autorisez {{parent}} à récupérer le bilan de votre empreinte climat.</0><1>Il s'agit de vos résultats sur les grandes catégories (transport, alimentation...), mais <1>pas</1> le détail question par question (vos km en voiture, les m² de votre logement...).</1><2>Nosgestesclimat.fr n'est pas affilié au site {{parent}}.</2>
   publicodes.fin.Petrogaz.equivalenceVolume: Soit {{secondaryValue}} litres (plein de {{pleinVolume}} litres).
-  publicodes.fin.Petrogaz.explications: <0>C'est une estimation <1>a minima</1> de
-    votre consommation de pétrole brut à l'année.</0><1>Estimée via vos trajets
-    en voiture, en avion, en bus, consommation de fioul pour chauffage, elle ne
-    prend pas (encore) en compte le pétrole utilisé pour acheminer vos achats,
-    et l'énergie grise de vos diverses possessions.</1>
+  publicodes.fin.Petrogaz.explications: <0>C'est une estimation <1>a minima</1> de votre consommation de pétrole brut à l'année.</0><1>Estimée via vos trajets en voiture, en avion, en bus, consommation de fioul pour chauffage, elle ne prend pas (encore) en compte le pétrole utilisé pour acheminer vos achats, et l'énergie grise de vos diverses possessions.</1>
   publicodes.fin.Petrogaz.petroleBrut: de <1>pétrole brut par an</1>
   période: période
   semaine: semaine
@@ -642,12 +427,9 @@ entries:
   simulation-end.title: 🌟 Vous avez complété cette simulation
   simulations: simulations
   simulations terminées depuis le lancement: simulations terminées depuis le lancement
-  site.publicodes.conferences.Stats.explication0: Chaque barre verticale ☝️ est le
-    score total d'un participant,<1></1>chaque disque 👇️ un score sur une
-    catégorie.
+  site.publicodes.conferences.Stats.explication0: Chaque barre verticale ☝️ est le score total d'un participant,<1></1>chaque disque 👇️ un score sur une catégorie.
   site.publicodes.conferences.Stats.explication1: '<0>En jaune</0> : mon score de {{spotlightValue}} t.'
-  sites.publicodes.Landing.description: En 10 minutes, obtenez une estimation de
-    votre empreinte carbone de consommation.
+  sites.publicodes.Landing.description: En 10 minutes, obtenez une estimation de votre empreinte carbone de consommation.
   sites.publicodes.LandingExplanations.faqLink: |-
     ## Des questions ?
 

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -200,7 +200,6 @@ function survey(state = null, { type, room, answers, contextFile }) {
 function conference(state = null, { type, room, ydoc, provider }) {
 	if (type === 'UNSET_CONFERENCE') return null
 	if (type === 'SET_CONFERENCE') {
-		if (state?.room === room) return state
 		return {
 			room,
 			ydoc,

--- a/source/reducers/rootReducer.ts
+++ b/source/reducers/rootReducer.ts
@@ -297,6 +297,11 @@ function localisation(
 		return null
 	} else return state
 }
+function sessionLocalisationBannersRead(state = [], { type, regions }) {
+	if (type === 'SET_LOCALISATION_BANNERS_READ') {
+		return regions
+	} else return state
+}
 
 function pullRequestNumber(state = null, { type, number }) {
 	if (type === 'SET_PULL_REQUEST_NUMBER') {
@@ -322,6 +327,7 @@ const mainReducer = (state: any, action: Action) =>
 		thenRedirectTo,
 		tracking,
 		localisation,
+		sessionLocalisationBannersRead,
 		pullRequestNumber,
 		engineState,
 		currentLang,

--- a/source/selectors/storageSelectors.ts
+++ b/source/selectors/storageSelectors.ts
@@ -13,6 +13,7 @@ export type SavedSimulation = {
 	// Current language used for the UI translation -- not the model.
 	currentLang: Lang
 	localisation: Object | undefined
+	conference: { room: string } | null
 }
 
 export const currentSimulationSelector = (
@@ -28,6 +29,7 @@ export const currentSimulationSelector = (
 		url: state.simulation?.url,
 		currentLang: state.currentLang,
 		localisation: state.localisation,
+		conference: state.conference && { room: state.conference.room },
 	}
 }
 

--- a/source/selectors/storageSelectors.ts
+++ b/source/selectors/storageSelectors.ts
@@ -14,6 +14,7 @@ export type SavedSimulation = {
 	currentLang: Lang
 	localisation: Object | undefined
 	conference: { room: string } | null
+	survey: { room: string } | null
 }
 
 export const currentSimulationSelector = (
@@ -30,6 +31,7 @@ export const currentSimulationSelector = (
 		currentLang: state.currentLang,
 		localisation: state.localisation,
 		conference: state.conference && { room: state.conference.room },
+		survey: state.survey && { room: state.survey.room },
 	}
 }
 

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -27,6 +27,7 @@ import {
 	getLangInfos,
 	Lang,
 } from './../../locales/translation'
+import GroupModeSessionVignette from './conference/GroupModeSessionVignette'
 import Landing from './Landing'
 import Navigation from './Navigation'
 import About from './pages/About'
@@ -189,6 +190,7 @@ const Main = ({}) => {
 						}
 					`}
 				>
+					<GroupModeSessionVignette />
 					{!isHomePage && !isTuto && <LocalisationMessage />}
 
 					{fluidLayout && (

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -103,6 +103,7 @@ export default function Root({}) {
 				currentLang,
 				localisation: persistedSimulation?.localisation,
 				conference: persistedSimulation?.conference,
+				survey: persistedSimulation?.survey,
 			}}
 		>
 			<Main />

--- a/source/sites/publicodes/App.tsx
+++ b/source/sites/publicodes/App.tsx
@@ -102,6 +102,7 @@ export default function Root({}) {
 				storedTrajets: persistedSimulation?.storedTrajets ?? {},
 				currentLang,
 				localisation: persistedSimulation?.localisation,
+				conference: persistedSimulation?.conference,
 			}}
 		>
 			<Main />

--- a/source/sites/publicodes/Landing.tsx
+++ b/source/sites/publicodes/Landing.tsx
@@ -80,7 +80,7 @@ export default () => {
 							font-size: 180%;
 						}
 					}
-					@media (max-height: 700px) {
+					@media (max-height: 600px) {
 						/*target iPhone 5 SE */
 						h1 {
 							font-size: 160%;

--- a/source/sites/publicodes/ScoreBar.tsx
+++ b/source/sites/publicodes/ScoreBar.tsx
@@ -67,7 +67,7 @@ export default ({ actionMode = false, demoMode = false }) => {
 					width: 100%;
 				}
 
-			@media (max-height: 700px) {
+			@media (max-height: 600px) {
 			bottom: 2rem
 
 			}

--- a/source/sites/publicodes/conference/CategoryStats.tsx
+++ b/source/sites/publicodes/conference/CategoryStats.tsx
@@ -1,9 +1,19 @@
 import { useTranslation } from 'react-i18next'
+import { sortBy } from '../../../utils'
 import { humanWeight } from '../HumanWeight'
 
-export default ({ categories, maxCategory, spotlight, setSpotlight }) => {
+export default ({
+	categories: decreasingCategories,
+	maxCategory,
+	spotlight,
+	setSpotlight,
+}) => {
 	const { t, i18n } = useTranslation()
-	const values = Object.values(categories)
+
+	const categories = sortBy(([key, values]) =>
+		values.reduce((memo, next) => memo + next, 0)
+	)(Object.entries(decreasingCategories))
+	const values = Object.values(decreasingCategories)
 			.flat()
 			.map(({ value }) => value),
 		max = Math.max(...values),
@@ -43,7 +53,7 @@ export default ({ categories, maxCategory, spotlight, setSpotlight }) => {
 					}
 				`}
 			>
-				{Object.entries(categories).map(([name, values]) => (
+				{categories.map(([name, values]) => (
 					<li key={name}>
 						<span>{name}</span>
 						<ul>

--- a/source/sites/publicodes/conference/Conference.tsx
+++ b/source/sites/publicodes/conference/Conference.tsx
@@ -21,11 +21,9 @@ import {
 
 export const ConferenceTitle = styled.h2`
 	margin-top: 0.6rem;
-	@media (min-width: 800px) {
-		display: none;
-	}
 	> img {
-		width: 4rem;
+		width: 3rem;
+		margin-right: 1rem;
 	}
 	display: flex;
 	align-items: center;

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -32,7 +32,7 @@ export default () => {
 	const nodeValue = correctValue({ nodeValue: rawNodeValue, unit })
 
 	useEffect(() => {
-		if (!conference?.ydoc) return null
+		if (!conference?.ydoc) return
 
 		const simulations = conference.ydoc.get('simulations', Y.Map)
 

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -9,8 +9,8 @@ import * as Y from 'yjs'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
 import { conferenceElementsAdapter } from './Conference'
+import { GroupModeMenuEntryContent } from './GroupModeSessionVignette'
 import { computeHumanMean } from './Stats'
-import { CountDisc, CountSection, EmojiStyle } from './SurveyBar'
 import useYjs from './useYjs'
 import { defaultProgressMin, defaultThreshold, getElements } from './utils'
 
@@ -53,7 +53,12 @@ export default () => {
 		)
 
 	const statElements = conferenceElementsAdapter(elements)
-	const rawNumber = getElements(statElements, defaultThreshold, null, 0).length
+	const rawUserNumber = getElements(
+		statElements,
+		defaultThreshold,
+		null,
+		0
+	).length
 
 	const completedTestNumber = getElements(
 		statElements,
@@ -62,62 +67,15 @@ export default () => {
 		defaultProgressMin
 	).length
 
-	//TODO mutualise this display part with SurveyBar
 	return (
-		<Link to={'/conférence/' + conference.room} css="text-decoration: none;">
-			<div
-				css={`
-					color: white;
-					padding: 0.3rem;
-					display: flex;
-					flex-direction: column;
-					@media (min-width: 800px) {
-						flex-direction: row;
-						padding: 0.3rem 3rem;
-					}
-
-					justify-content: space-evenly;
-					align-items: center;
-					> span {
-						display: flex;
-						align-items: center;
-					}
-
-					img {
-						font-size: 150%;
-						margin-right: 0.4rem !important;
-					}
-				`}
-			>
-				<span css="">«&nbsp;{conference.room}&nbsp;»</span>
-				<div
-					css={`
-						display: flex;
-						justify-content: space-evenly;
-						align-items: center;
-						width: 100%;
-					`}
-				>
-					<span>
-						<EmojiStyle>🧮</EmojiStyle>
-						{result.replace(/tonnes?/, 't')}
-					</span>
-					<CountSection>
-						{rawNumber != null && (
-							<span title={t('Nombre total de participants')}>
-								<EmojiStyle>👥</EmojiStyle>
-								<CountDisc color="#55acee">{rawNumber}</CountDisc>
-							</span>
-						)}
-						{completedTestNumber != null && (
-							<span title={t('Nombre de tests terminés')}>
-								<EmojiStyle>✅</EmojiStyle>
-								<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
-							</span>
-						)}
-					</CountSection>
-				</div>
-			</div>
-		</Link>
+		<GroupModeMenuEntryContent
+			{...{
+				groupMode: 'conférence',
+				room: conference.room,
+				rawUserNumber,
+				completedTestNumber,
+				result,
+			}}
+		/>
 	)
 }

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -68,14 +68,12 @@ export default () => {
 			<div
 				css={`
 					color: white;
-					padding: 0.3rem 1rem;
+					padding: 0.3rem;
 					display: flex;
 					flex-direction: column;
 
 					justify-content: space-evenly;
 					align-items: center;
-					border-bottom-right-radius: 0.4rem;
-					border-bottom-left-radius: 0.4rem;
 					> span {
 						display: flex;
 						align-items: center;
@@ -89,9 +87,7 @@ export default () => {
 					}
 				`}
 			>
-				<span css="text-transform: uppercase">
-					«&nbsp;{conference.room}&nbsp;»
-				</span>
+				<span css="">«&nbsp;{conference.room}&nbsp;»</span>
 				<div
 					css={`
 						display: flex;
@@ -102,7 +98,7 @@ export default () => {
 				>
 					<span>
 						<EmojiStyle>🧮</EmojiStyle>
-						{result}
+						{result.replace(/tonnes?/, 't')}
 					</span>
 					<CountSection>
 						{rawNumber != null && (

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -9,7 +9,6 @@ import * as Y from 'yjs'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
 import { conferenceElementsAdapter } from './Conference'
-import { backgroundConferenceAnimation } from './conferenceStyle'
 import { computeHumanMean } from './Stats'
 import { CountDisc, CountSection, EmojiStyle } from './SurveyBar'
 import useYjs from './useYjs'
@@ -68,10 +67,11 @@ export default () => {
 		<Link to={'/conférence/' + conference.room} css="text-decoration: none;">
 			<div
 				css={`
-					${backgroundConferenceAnimation}
 					color: white;
 					padding: 0.3rem 1rem;
 					display: flex;
+					flex-direction: column;
+
 					justify-content: space-evenly;
 					align-items: center;
 					border-bottom-right-radius: 0.4rem;
@@ -80,40 +80,45 @@ export default () => {
 						display: flex;
 						align-items: center;
 					}
+
 					img {
 						font-size: 150%;
 						margin-right: 0.4rem !important;
 					}
 					@media (min-width: 800px) {
-						flex-direction: column;
-						align-items: start;
-						> * {
-							margin: 0.3rem 0;
-						}
 					}
 				`}
 			>
 				<span css="text-transform: uppercase">
 					«&nbsp;{conference.room}&nbsp;»
 				</span>
-				<span>
-					<EmojiStyle>🧮</EmojiStyle>
-					{result}
-				</span>
-				<CountSection>
-					{rawNumber != null && (
-						<span title={t('Nombre total de participants')}>
-							<EmojiStyle>👥</EmojiStyle>
-							<CountDisc color="#55acee">{rawNumber}</CountDisc>
-						</span>
-					)}
-					{completedTestNumber != null && (
-						<span title={t('Nombre de tests terminés')}>
-							<EmojiStyle>✅</EmojiStyle>
-							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
-						</span>
-					)}
-				</CountSection>
+				<div
+					css={`
+						display: flex;
+						justify-content: space-evenly;
+						align-items: center;
+						width: 100%;
+					`}
+				>
+					<span>
+						<EmojiStyle>🧮</EmojiStyle>
+						{result}
+					</span>
+					<CountSection>
+						{rawNumber != null && (
+							<span title={t('Nombre total de participants')}>
+								<EmojiStyle>👥</EmojiStyle>
+								<CountDisc color="#55acee">{rawNumber}</CountDisc>
+							</span>
+						)}
+						{completedTestNumber != null && (
+							<span title={t('Nombre de tests terminés')}>
+								<EmojiStyle>✅</EmojiStyle>
+								<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
+							</span>
+						)}
+					</CountSection>
+				</div>
 			</div>
 		</Link>
 	)

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -71,6 +71,10 @@ export default () => {
 					padding: 0.3rem;
 					display: flex;
 					flex-direction: column;
+					@media (min-width: 800px) {
+						flex-direction: row;
+						padding: 0.3rem 3rem;
+					}
 
 					justify-content: space-evenly;
 					align-items: center;
@@ -82,8 +86,6 @@ export default () => {
 					img {
 						font-size: 150%;
 						margin-right: 0.4rem !important;
-					}
-					@media (min-width: 800px) {
 					}
 				`}
 			>

--- a/source/sites/publicodes/conference/ConferenceBar.tsx
+++ b/source/sites/publicodes/conference/ConferenceBar.tsx
@@ -74,6 +74,8 @@ export default () => {
 					display: flex;
 					justify-content: space-evenly;
 					align-items: center;
+					border-bottom-right-radius: 0.4rem;
+					border-bottom-left-radius: 0.4rem;
 					> span {
 						display: flex;
 						align-items: center;

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -28,7 +28,7 @@ export default () => {
 			{survey?.room && (
 				<GroupModeMenuEntry
 					title="Sondage"
-					icon={openmojiURL('sondage')}
+					icon={openmojiURL('conference')}
 					url={'/sondage/' + survey.room}
 				>
 					<SurveyBarLazy />

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -17,15 +17,12 @@ export default () => {
 	return (
 		<>
 			{conference?.room && (
-				<GroupModeMenuEntry
-					title="Conférence"
-					url={'/conférence/' + conference.room}
-				>
+				<GroupModeMenuEntry groupMode="conférence" room={conference.room}>
 					<ConferenceBarLazy />
 				</GroupModeMenuEntry>
 			)}
 			{survey?.room && (
-				<GroupModeMenuEntry title="Sondage" url={'/sondage/' + survey.room}>
+				<GroupModeMenuEntry groupMode="sondage" room={survey.room}>
 					<SurveyBarLazy />
 				</GroupModeMenuEntry>
 			)}
@@ -35,42 +32,43 @@ export default () => {
 
 const Button = styled.button``
 
-const GroupModeMenuEntry = ({ title, url, children }) => {
+const GroupModeMenuEntry = ({ groupMode, room, children }) => {
 	return (
 		<div
 			css={`
 				margin-bottom: 1rem;
 			`}
 		>
-			<Button
-				className="simple small"
-				css={`
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					width: 100%;
-					font-style: italic;
-					margin-bottom: 0.2rem;
-				`}
-			>
-				⟵ revenir aux résultats{' '}
-				{title === 'sondage' ? 'du sondage' : 'de la conf.'}
-			</Button>
-			<div
-				css={`
-					${backgroundConferenceAnimation}
-					border-radius: 0.4rem;
-					margin-right: 0.6rem;
-				`}
-			>
-				{children}
-			</div>
+			<Link to={`/${groupMode}/${room}`} css="text-decoration: none;">
+				<Button
+					className="simple small"
+					css={`
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						width: 100%;
+						font-style: italic;
+						margin-bottom: 0.2rem;
+					`}
+				>
+					⟵ revenir aux résultats{' '}
+					{groupMode === 'sondage' ? 'du sondage' : 'de la conf.'}
+				</Button>
+				<div
+					css={`
+						${backgroundConferenceAnimation}
+						border-radius: 0.4rem;
+						margin-right: 0.6rem;
+					`}
+				>
+					{children}
+				</div>
+			</Link>
 		</div>
 	)
 }
 
 export const GroupModeMenuEntryContent = ({
-	groupMode,
 	room,
 	result,
 	rawUserNumber,
@@ -78,80 +76,78 @@ export const GroupModeMenuEntryContent = ({
 }) => {
 	const { t } = useTranslation()
 	return (
-		<Link to={`/${groupMode}/${room}`} css="text-decoration: none;">
+		<div
+			css={`
+				color: white;
+				padding: 0.3rem;
+				display: flex;
+				flex-direction: column;
+				@media (min-width: 800px) {
+					flex-direction: row;
+					padding: 0.3rem 3rem;
+				}
+
+				justify-content: space-evenly;
+				align-items: center;
+				> span {
+					display: flex;
+					align-items: center;
+				}
+
+				img {
+					font-size: 150%;
+					margin-right: 0.4rem !important;
+				}
+			`}
+		>
 			<div
 				css={`
-					color: white;
-					padding: 0.3rem;
 					display: flex;
-					flex-direction: column;
-					@media (min-width: 800px) {
-						flex-direction: row;
-						padding: 0.3rem 3rem;
-					}
-
-					justify-content: space-evenly;
-					align-items: center;
-					> span {
-						display: flex;
-						align-items: center;
-					}
-
-					img {
-						font-size: 150%;
-						margin-right: 0.4rem !important;
-					}
 				`}
 			>
-				<div
+				<img
+					src={openmojiURL('conference')}
 					css={`
-						display: flex;
+						width: 1.8rem;
+						height: auto;
+						margin: 0 0.6rem;
 					`}
-				>
-					<img
-						src={openmojiURL('conference')}
-						css={`
-							width: 1.8rem;
-							height: auto;
-							margin: 0 0.6rem;
-						`}
-						aria-hidden="true"
-						width="1"
-						height="1"
-					/>
-					<span css="">«&nbsp;{room}&nbsp;»</span>
-				</div>
-				<div
-					css={`
-						display: flex;
-						justify-content: space-evenly;
-						align-items: center;
-						width: 100%;
-					`}
-				>
-					{result && (
-						<span>
-							<EmojiStyle>🧮</EmojiStyle>
-							{result.replace(/tonnes?/, 't')}
+					aria-hidden="true"
+					width="1"
+					height="1"
+				/>
+				<span css="">«&nbsp;{room}&nbsp;»</span>
+			</div>
+			<div
+				css={`
+					display: flex;
+					justify-content: space-evenly;
+					align-items: center;
+					width: 100%;
+				`}
+			>
+				{result && (
+					<span>
+						<EmojiStyle>🧮</EmojiStyle>
+						{result.replace(/tonnes?/, 't')}
+					</span>
+				)}
+				<CountSection>
+					{rawUserNumber != null && (
+						<span title={t('Nombre total de participants')}>
+							<EmojiStyle>👥</EmojiStyle>
+							<CountDisc color="#55acee">{rawUserNumber}</CountDisc>
 						</span>
 					)}
-					<CountSection>
-						{rawUserNumber != null && (
-							<span title={t('Nombre total de participants')}>
-								<EmojiStyle>👥</EmojiStyle>
-								<CountDisc color="#55acee">{rawUserNumber}</CountDisc>
-							</span>
-						)}
-						{completedTestNumber != null && (
-							<span title={t('Nombre de tests terminés')}>
-								<EmojiStyle>✅</EmojiStyle>
-								<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
-							</span>
-						)}
-					</CountSection>
-				</div>
+					{completedTestNumber != null && (
+						<span title={t('Nombre de tests terminés')}>
+							<EmojiStyle>✅</EmojiStyle>
+							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
+						</span>
+					)}
+				</CountSection>
 			</div>
-		</Link>
+		</div>
 	)
 }
 

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { openmojiURL } from '../../../components/SessionBar'
 import ConferenceBarLazy from './ConferenceBarLazy'
@@ -6,6 +7,8 @@ import { backgroundConferenceAnimation } from './conferenceStyle'
 import SurveyBarLazy from './SurveyBarLazy'
 
 export default () => {
+	const location = useLocation()
+	if (!['/simulateur/bilan', '/groupe'].includes(location.pathname)) return null
 	const conference = useSelector((state) => state.conference)
 	const survey = useSelector((state) => state.survey)
 
@@ -45,20 +48,21 @@ const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 					align-items: center;
 					justify-content: center;
 					width: 100%;
+					font-style: italic;
 				`}
 			>
 				<img
 					src={icon}
 					css={`
-						width: 2rem;
-						height: 2rem;
+						width: 1.8rem;
+						height: auto;
 						margin: 0 0.6rem;
 					`}
 					aria-hidden="true"
 					width="1"
 					height="1"
 				/>
-				{title}
+				{title} en cours
 			</Button>
 			<div
 				css={`

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -40,7 +40,11 @@ const Button = styled.button``
 
 const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 	return (
-		<div>
+		<div
+			css={`
+				margin-bottom: 1rem;
+			`}
+		>
 			<Button
 				className="simple small"
 				css={`

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -19,18 +19,13 @@ export default () => {
 			{conference?.room && (
 				<GroupModeMenuEntry
 					title="Conférence"
-					icon={openmojiURL('conference')}
 					url={'/conférence/' + conference.room}
 				>
 					<ConferenceBarLazy />
 				</GroupModeMenuEntry>
 			)}
 			{survey?.room && (
-				<GroupModeMenuEntry
-					title="Sondage"
-					icon={openmojiURL('conference')}
-					url={'/sondage/' + survey.room}
-				>
+				<GroupModeMenuEntry title="Sondage" url={'/sondage/' + survey.room}>
 					<SurveyBarLazy />
 				</GroupModeMenuEntry>
 			)}
@@ -40,7 +35,7 @@ export default () => {
 
 const Button = styled.button``
 
-const GroupModeMenuEntry = ({ title, icon, url, children }) => {
+const GroupModeMenuEntry = ({ title, url, children }) => {
 	return (
 		<div
 			css={`
@@ -55,20 +50,11 @@ const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 					justify-content: center;
 					width: 100%;
 					font-style: italic;
+					margin-bottom: 0.2rem;
 				`}
 			>
-				<img
-					src={icon}
-					css={`
-						width: 1.8rem;
-						height: auto;
-						margin: 0 0.6rem;
-					`}
-					aria-hidden="true"
-					width="1"
-					height="1"
-				/>
-				{title} en cours
+				⟵ revenir aux résultats{' '}
+				{title === 'sondage' ? 'du sondage' : 'de la conf.'}
 			</Button>
 			<div
 				css={`
@@ -117,7 +103,24 @@ export const GroupModeMenuEntryContent = ({
 					}
 				`}
 			>
-				<span css="">«&nbsp;{room}&nbsp;»</span>
+				<div
+					css={`
+						display: flex;
+					`}
+				>
+					<img
+						src={openmojiURL('conference')}
+						css={`
+							width: 1.8rem;
+							height: auto;
+							margin: 0 0.6rem;
+						`}
+						aria-hidden="true"
+						width="1"
+						height="1"
+					/>
+					<span css="">«&nbsp;{room}&nbsp;»</span>
+				</div>
 				<div
 					css={`
 						display: flex;

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -1,0 +1,77 @@
+import { useSelector } from 'react-redux'
+import styled from 'styled-components'
+import { openmojiURL } from '../../../components/SessionBar'
+import ConferenceBarLazy from './ConferenceBarLazy'
+import { backgroundConferenceAnimation } from './conferenceStyle'
+import SurveyBarLazy from './SurveyBarLazy'
+
+export default () => {
+	const conference = useSelector((state) => state.conference)
+	const survey = useSelector((state) => state.survey)
+
+	return (
+		<>
+			{conference?.room && (
+				<GroupModeMenuEntry
+					title="Conférence"
+					icon={openmojiURL('conference')}
+					url={'/conférence/' + conference.room}
+				>
+					<ConferenceBarLazy />
+				</GroupModeMenuEntry>
+			)}
+			{survey?.room && (
+				<GroupModeMenuEntry
+					title="Sondage"
+					icon={openmojiURL('sondage')}
+					url={'/sondage/' + survey.room}
+				>
+					<SurveyBarLazy />
+				</GroupModeMenuEntry>
+			)}
+		</>
+	)
+}
+
+const Button = styled.button``
+
+const GroupModeMenuEntry = ({ title, icon, url, children }) => {
+	return (
+		<div
+			css={`
+				${backgroundConferenceAnimation}
+				color: white;
+				border-radius: 0.4rem;
+				margin-right: 0.6rem;
+			`}
+		>
+			<Button
+				className="simple small"
+				css={`
+					padding: 0.4rem;
+					color: white;
+					img {
+						filter: invert(1);
+						background: none;
+						margin: 0 0.6rem 0 0 !important;
+					}
+					@media (max-width: 800px) {
+						img {
+							margin: 0 !important;
+						}
+					}
+				`}
+			>
+				<img
+					src={icon}
+					css="width: 2rem"
+					aria-hidden="true"
+					width="1"
+					height="1"
+				/>
+				{title}
+			</Button>
+			<div css={``}>{children}</div>
+		</div>
+	)
+}

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -37,41 +37,39 @@ const Button = styled.button``
 
 const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 	return (
-		<div
-			css={`
-				${backgroundConferenceAnimation}
-				color: white;
-				border-radius: 0.4rem;
-				margin-right: 0.6rem;
-			`}
-		>
+		<div>
 			<Button
 				className="simple small"
 				css={`
-					padding: 0.4rem;
-					color: white;
-					img {
-						filter: invert(1);
-						background: none;
-						margin: 0 0.6rem 0 0 !important;
-					}
-					@media (max-width: 800px) {
-						img {
-							margin: 0 !important;
-						}
-					}
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					width: 100%;
 				`}
 			>
 				<img
 					src={icon}
-					css="width: 2rem"
+					css={`
+						width: 2rem;
+						height: 2rem;
+						margin: 0 0.6rem;
+					`}
 					aria-hidden="true"
 					width="1"
 					height="1"
 				/>
 				{title}
 			</Button>
-			<div css={``}>{children}</div>
+			<div
+				css={`
+					${backgroundConferenceAnimation}
+					color: white;
+					border-radius: 0.4rem;
+					margin-right: 0.6rem;
+				`}
+			>
+				{children}
+			</div>
 		</div>
 	)
 }

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -9,7 +9,11 @@ import SurveyBarLazy from './SurveyBarLazy'
 
 export default () => {
 	const location = useLocation()
-	if (!['/simulateur/bilan', '/groupe', '/profil'].includes(location.pathname))
+	if (
+		!['/simulateur/bilan', '/groupe', '/profil', '/sondage'].some((el) =>
+			location.pathname.includes(el)
+		)
+	)
 		return null
 	const conference = useSelector((state) => state.conference)
 	const survey = useSelector((state) => state.survey)
@@ -33,6 +37,7 @@ export default () => {
 const Button = styled.button``
 
 const GroupModeMenuEntry = ({ groupMode, room, children }) => {
+	const showBackButton = !useLocation().pathname.includes('/sondage/')
 	return (
 		<div
 			css={`
@@ -40,20 +45,22 @@ const GroupModeMenuEntry = ({ groupMode, room, children }) => {
 			`}
 		>
 			<Link to={`/${groupMode}/${room}`} css="text-decoration: none;">
-				<Button
-					className="simple small"
-					css={`
-						display: flex;
-						align-items: center;
-						justify-content: center;
-						width: 100%;
-						font-style: italic;
-						margin-bottom: 0.2rem;
-					`}
-				>
-					⟵ revenir aux résultats{' '}
-					{groupMode === 'sondage' ? 'du sondage' : 'de la conf.'}
-				</Button>
+				{showBackButton && (
+					<Button
+						className="simple small"
+						css={`
+							display: flex;
+							align-items: center;
+							justify-content: center;
+							width: 100%;
+							font-style: italic;
+							margin-bottom: 0.2rem;
+						`}
+					>
+						⟵ revenir aux résultats{' '}
+						{groupMode === 'sondage' ? 'du sondage' : 'de la conf.'}
+					</Button>
+				)}
 				<div
 					css={`
 						${backgroundConferenceAnimation}

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -8,7 +8,8 @@ import SurveyBarLazy from './SurveyBarLazy'
 
 export default () => {
 	const location = useLocation()
-	if (!['/simulateur/bilan', '/groupe'].includes(location.pathname)) return null
+	if (!['/simulateur/bilan', '/groupe', '/profil'].includes(location.pathname))
+		return null
 	const conference = useSelector((state) => state.conference)
 	const survey = useSelector((state) => state.survey)
 

--- a/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
+++ b/source/sites/publicodes/conference/GroupModeSessionVignette.tsx
@@ -1,5 +1,6 @@
+import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { openmojiURL } from '../../../components/SessionBar'
 import ConferenceBarLazy from './ConferenceBarLazy'
@@ -72,7 +73,6 @@ const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 			<div
 				css={`
 					${backgroundConferenceAnimation}
-					color: white;
 					border-radius: 0.4rem;
 					margin-right: 0.6rem;
 				`}
@@ -82,3 +82,95 @@ const GroupModeMenuEntry = ({ title, icon, url, children }) => {
 		</div>
 	)
 }
+
+export const GroupModeMenuEntryContent = ({
+	groupMode,
+	room,
+	result,
+	rawUserNumber,
+	completedTestNumber,
+}) => {
+	const { t } = useTranslation()
+	return (
+		<Link to={`/${groupMode}/${room}`} css="text-decoration: none;">
+			<div
+				css={`
+					color: white;
+					padding: 0.3rem;
+					display: flex;
+					flex-direction: column;
+					@media (min-width: 800px) {
+						flex-direction: row;
+						padding: 0.3rem 3rem;
+					}
+
+					justify-content: space-evenly;
+					align-items: center;
+					> span {
+						display: flex;
+						align-items: center;
+					}
+
+					img {
+						font-size: 150%;
+						margin-right: 0.4rem !important;
+					}
+				`}
+			>
+				<span css="">«&nbsp;{room}&nbsp;»</span>
+				<div
+					css={`
+						display: flex;
+						justify-content: space-evenly;
+						align-items: center;
+						width: 100%;
+					`}
+				>
+					{result && (
+						<span>
+							<EmojiStyle>🧮</EmojiStyle>
+							{result.replace(/tonnes?/, 't')}
+						</span>
+					)}
+					<CountSection>
+						{rawUserNumber != null && (
+							<span title={t('Nombre total de participants')}>
+								<EmojiStyle>👥</EmojiStyle>
+								<CountDisc color="#55acee">{rawUserNumber}</CountDisc>
+							</span>
+						)}
+						{completedTestNumber != null && (
+							<span title={t('Nombre de tests terminés')}>
+								<EmojiStyle>✅</EmojiStyle>
+								<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
+							</span>
+						)}
+					</CountSection>
+				</div>
+			</div>
+		</Link>
+	)
+}
+
+export const EmojiStyle = styled.span`
+	font-size: 130%;
+	margin-right: 0.4rem;
+`
+
+export const CountSection = styled.div`
+	display: flex;
+	> * {
+		margin: 0 0.6rem;
+	}
+`
+
+export const CountDisc = styled.span`
+	background: ${(props) => props.color};
+	width: 1.3rem;
+	height: 1.3rem;
+	border-radius: 2rem;
+	display: inline-block;
+	line-height: 1.3rem;
+	text-align: center;
+	color: var(--darkerColor);
+`

--- a/source/sites/publicodes/conference/Instructions.tsx
+++ b/source/sites/publicodes/conference/Instructions.tsx
@@ -44,7 +44,7 @@ export default ({
 					<p>
 						Le test d'empreinte climat est individuel, mais nous vous proposons
 						ici de le faire à plusieurs. Chacun sera derrière son écran, mais
-						visualisera en temps réel les résultats des autres.
+						pourra voir en temps réel les résultats des autres.
 					</p>
 					<p>
 						C'est l'occasion de réfléchir ensemble aux enjeux de notre propre

--- a/source/sites/publicodes/conference/NamingBlock.tsx
+++ b/source/sites/publicodes/conference/NamingBlock.tsx
@@ -43,6 +43,7 @@ export default ({ newRoom, setNewRoom }) => {
 			</form>
 
 			<button
+				css="margin-bottom:.4rem !important"
 				onClick={() => setNewRoom(generateRoomName())}
 				className="ui__ dashed-button"
 			>

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -225,10 +225,12 @@ const DownloadInteractiveButton = ({ url, isRegisteredSurvey }) => {
 }
 
 export const surveyElementsAdapter = (items) =>
-	Object.values(items).map((el) => ({
-		...el.data,
-		username: el.id,
-	}))
+	items
+		? Object.values(items).map((el) => ({
+				...el.data,
+				username: el.id,
+		  }))
+		: []
 
 const Results = ({ room, existContext, contextRules }) => {
 	const [cachedSurveyIds] = usePersistingState('surveyIds', {})

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -117,7 +117,6 @@ export default () => {
 			)}
 			{survey && survey.room === room && (
 				<>
-					<Instructions {...{ room, mode: 'sondage', started: true }} />
 					<div>
 						<button
 							className="ui__ link-button"
@@ -130,6 +129,7 @@ export default () => {
 							{emoji('🚪')} Quitter le sondage
 						</button>
 					</div>
+					<Instructions {...{ room, mode: 'sondage', started: true }} />
 					<DownloadInteractiveButton
 						url={answersURL + room + '?format=csv'}
 						isRegisteredSurvey={isRegisteredSurvey}

--- a/source/sites/publicodes/conference/Survey.tsx
+++ b/source/sites/publicodes/conference/Survey.tsx
@@ -5,12 +5,10 @@ import { useParams } from 'react-router'
 import { useNavigate } from 'react-router-dom'
 
 import { Trans, useTranslation } from 'react-i18next'
-import { conferenceImg } from '../../../components/SessionBar'
 import Meta from '../../../components/utils/Meta'
 import { usePersistingState } from '../../../components/utils/persistState'
 import Navigation from '../Navigation'
 import { useProfileData } from '../Profil'
-import { ConferenceTitle } from './Conference'
 import ContextConversation from './ContextConversation'
 import DataWarning from './DataWarning'
 import Instructions from './Instructions'
@@ -89,10 +87,6 @@ export default () => {
 					<NoSurveyCreatedWarning />
 				</div>
 			)}
-			<ConferenceTitle>
-				<img src={conferenceImg} alt="" />
-				<span css="text-transform: uppercase">«&nbsp;{room}&nbsp;»</span>
-			</ConferenceTitle>
 			{!survey || survey.room !== room ? (
 				<DataWarning room={room} />
 			) : (

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -8,12 +8,11 @@ import { usePersistingState } from 'Components/utils/persistState'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link } from 'react-router-dom'
 import { situationSelector } from 'Selectors/simulationSelectors'
-import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 import { minimalCategoryData } from '../../../components/publicodesUtils'
 import { useSimulationProgress } from '../../../components/utils/useNextQuestion'
+import { GroupModeMenuEntryContent } from './GroupModeSessionVignette'
 import { computeHumanMean } from './Stats'
 import { surveyElementsAdapter } from './Survey'
 import useDatabase, { answersURL } from './useDatabase'
@@ -106,7 +105,6 @@ export default () => {
 
 	useEffect(() => {
 		const onReceived = (data) => {
-			console.log('YOYOOY', survey)
 			dispatch({
 				type: 'ADD_SURVEY_ANSWERS',
 				answers: [data.answer],
@@ -130,7 +128,7 @@ export default () => {
 	const existContext = survey ? !(survey['contextFile'] == null) : false
 
 	const elements = surveyElementsAdapter(survey.answers)
-	const rawNumber = getElements(
+	const rawUserNumber = getElements(
 		elements,
 		defaultThreshold,
 		existContext,
@@ -147,71 +145,14 @@ export default () => {
 	if (DBError) return <div className="ui__ card plain">{DBError}</div>
 
 	return (
-		<Link to={'/sondage/' + survey.room} css="text-decoration: none;">
-			<div
-				css={`
-					color: white;
-					padding: 0.3rem 1rem;
-					display: flex;
-					justify-content: space-evenly;
-					align-items: center;
-					> span {
-						display: flex;
-						align-items: center;
-					}
-					@media (min-width: 800px) {
-						flex-direction: column;
-						align-items: start;
-						> * {
-							margin: 0.3rem 0;
-						}
-					}
-				`}
-			>
-				<span css="text-transform: uppercase">«&nbsp;{survey.room}&nbsp;»</span>
-				{result && (
-					<span>
-						<EmojiStyle>🧮</EmojiStyle> {result}
-					</span>
-				)}
-				<CountSection>
-					{rawNumber != null && (
-						<span title={t('Nombre total de participants')}>
-							<EmojiStyle>👥</EmojiStyle>
-							<CountDisc color="#55acee">{rawNumber}</CountDisc>
-						</span>
-					)}
-					{completedTestNumber != null && (
-						<span title={t('Nombre de tests terminés')}>
-							<EmojiStyle>✅</EmojiStyle>
-							<CountDisc color="#78b159">{completedTestNumber}</CountDisc>
-						</span>
-					)}
-				</CountSection>
-			</div>
-		</Link>
+		<GroupModeMenuEntryContent
+			{...{
+				room: survey.room,
+				rawUserNumber,
+				completedTestNumber,
+				result,
+				groupMode: 'sondage',
+			}}
+		/>
 	)
 }
-
-export const EmojiStyle = styled.span`
-	font-size: 130%;
-	margin-right: 0.4rem;
-`
-
-export const CountSection = styled.div`
-	display: flex;
-	> * {
-		margin: 0 0.6rem;
-	}
-`
-
-export const CountDisc = styled.span`
-	background: ${(props) => props.color};
-	width: 1.3rem;
-	height: 1.3rem;
-	border-radius: 2rem;
-	display: inline-block;
-	line-height: 1.3rem;
-	text-align: center;
-	color: var(--darkerColor);
-`

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -119,7 +119,6 @@ export default () => {
 
 	const simulationArray = [],
 		result =
-			null &&
 			computeHumanMean(
 				translation,
 				simulationArray.map((el) => el.total)

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -159,10 +159,6 @@ export default () => {
 						display: flex;
 						align-items: center;
 					}
-					img {
-						font-size: 150%;
-						margin-right: 0.4rem !important;
-					}
 					@media (min-width: 800px) {
 						flex-direction: column;
 						align-items: start;
@@ -173,7 +169,11 @@ export default () => {
 				`}
 			>
 				<span css="text-transform: uppercase">«&nbsp;{survey.room}&nbsp;»</span>
-				{result && <span>🧮 {result}</span>}
+				{result && (
+					<span>
+						<EmojiStyle>🧮</EmojiStyle> {result}
+					</span>
+				)}
 				<CountSection>
 					{rawNumber != null && (
 						<span title={t('Nombre total de participants')}>
@@ -194,7 +194,7 @@ export default () => {
 }
 
 export const EmojiStyle = styled.span`
-	font-size: 150%;
+	font-size: 130%;
 	margin-right: 0.4rem;
 `
 
@@ -207,11 +207,11 @@ export const CountSection = styled.div`
 
 export const CountDisc = styled.span`
 	background: ${(props) => props.color};
-	width: 1.5rem;
-	height: 1.5rem;
+	width: 1.3rem;
+	height: 1.3rem;
 	border-radius: 2rem;
 	display: inline-block;
-	line-height: 1.5rem;
+	line-height: 1.3rem;
 	text-align: center;
 	color: var(--darkerColor);
 `

--- a/source/sites/publicodes/conference/SurveyBar.tsx
+++ b/source/sites/publicodes/conference/SurveyBar.tsx
@@ -200,8 +200,9 @@ export const EmojiStyle = styled.span`
 
 export const CountSection = styled.div`
 	display: flex;
-	justify-content: space-between;
-	width: 100%;
+	> * {
+		margin: 0 0.6rem;
+	}
 `
 
 export const CountDisc = styled.span`

--- a/source/sites/publicodes/conference/useYjs.tsx
+++ b/source/sites/publicodes/conference/useYjs.tsx
@@ -8,8 +8,10 @@ import { generateFruitName, stringToColour } from './utils'
 
 localStorage.log = 'y-webrtc'
 
-export default (room, connectionType: 'p2p' | 'database') => {
-	const conference = useSelector((state) => state.conference)
+export default (providedRoom, connectionType: 'p2p' | 'database') => {
+	const conference = useSelector((state) => state.conference),
+		stateRoom = conference && conference.room,
+		room = providedRoom || stateRoom
 
 	const dispatch = useDispatch()
 	const [rawElements, setElements] = useState([])
@@ -24,7 +26,8 @@ export default (room, connectionType: 'p2p' | 'database') => {
 
 	useEffect(() => {
 		if (!username || (!room && !conference)) return
-		if (!conference) {
+		if (!conference || !conference.ydoc) {
+			console.log('will create new ydoc for room ', room)
 			const ydoc = new Y.Doc()
 			const provider =
 				connectionType === 'p2p'


### PR DESCRIPTION
> :game_die: 
> Démo https://deploy-preview-866--nosgestesclimat.netlify.app/conférence/ma-super-conf-de-test

Pour l'instant, je bosse sur le mode conf, qui est très similaire au mode sondage en termes d'UX, mais qui a l'avantage de marcher en lien de démo. Les deux ont été codé avec un manque de partage de composants, d'où le gain de temps de valider dans le principe le design de l'un avant de faire l'autre. 

- iframeresizer plus nécessaire dans yarn.lock
- Désactivation du bouton personas en mode dev
- Nouvelle entrée menu "groupe"; "Mon profil"-> "Profil"; alignement hz
- Simplification et justesse du texte intro groupe
- Fin de l'affichage du drapeau de région
- Bords arrondis pour la vignette conférence active
- Taille erronée sur bureau pour les entrées du menu
- Changement de style de fond pour les entrées menu actives
- Début du déplacement de la vignette de groupe actif vers le haut
- la rendre horizontale
- on harmonise ainsi mobile et bureau
- on permet sur mobile de voir le score de la conf en direct quand on fait son test
- on garde le menu simple, non mouvant



Fixes #858 #859 #860

![Recording 2023-03-01 at 16 03 07](https://user-images.githubusercontent.com/1177762/222178561-384aba27-a900-4dbe-9588-2cc072fae54b.gif)
