### PR TITLE
Nouveau serveur de signalement conférence y-webrtc, chez nous

### DIFF
--- a/scripts/fetch-releases.js
+++ b/scripts/fetch-releases.js
@@ -34,6 +34,7 @@ async function fetchReleases() {
 			`https://api.github.com/repos/${organization}/${repository}/releases`
 		)
 		const data = await response.json()
+		if (!data) console.error('fetch release failed : no release returned')
 		return data.filter(Boolean)
 	} catch (e) {
 		console.log(e)

--- a/source/sites/publicodes/conference/useYjs.tsx
+++ b/source/sites/publicodes/conference/useYjs.tsx
@@ -28,7 +28,11 @@ export default (room, connectionType: 'p2p' | 'database') => {
 			const ydoc = new Y.Doc()
 			const provider =
 				connectionType === 'p2p'
-					? new WebrtcProvider(room, ydoc, {})
+					? new WebrtcProvider(room, ydoc, {
+							signaling: [
+								'wss://nosgestesclimat-conference.osc-fr1.scalingo.io/',
+							],
+					  })
 					: new WebsocketProvider(
 							'wss://nosgestesclimat-serveur.osc-fr1.scalingo.io', // Not used, was a test, replace by Survey.tsx mode
 							room,


### PR DESCRIPTION
Fixes #875 

On héberge chez nous via https://github.com/datagir/nosgestesclimat-conference
