### PR TITLE
🐛 Fix bug bouton précédent

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -219,9 +219,11 @@ export default function Conversation({
 				  previousAnswers[previousAnswers.length - 1]
 				: // mosaics are exceptionnal, since they are similar questions grouped for the UI
 				mosaicQuestion
-				? [...previousAnswers].reverse().find((el, index) => {
+				? // We'll explore the previous answers starting from the end, to find the first question that is not in the current mosaic
+				  [...previousAnswers].reverse().find((el, index) => {
 						return (
 							index > previousAnswers.length - currentQuestionIndex &&
+							// The previous question shouldn't be one of the current mosaic's questions
 							!questionsToSubmit.includes(el)
 						)
 				  })

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -216,12 +216,12 @@ export default function Conversation({
 			currentQuestionIndex < 0 && previousAnswers.length > 0
 				? previousAnswers[previousAnswers.length - 1]
 				: mosaicQuestion
-				? [...previousAnswers]
-						.reverse()
-						.find(
-							(el, index) =>
-								index < currentQuestionIndex && !questionsToSubmit.includes(el)
+				? [...previousAnswers].reverse().find((el, index) => {
+						return (
+							index > previousAnswers.length - currentQuestionIndex &&
+							!questionsToSubmit.includes(el)
 						)
+				  })
 				: previousAnswers[currentQuestionIndex - 1]
 
 	const isValidInput = (questionsToSubmit) => {

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -212,10 +212,13 @@ export default function Conversation({
 	const currentQuestionIndex = previousAnswers.findIndex(
 			(a) => a === unfoldedStep
 		),
+		currentIsNew = currentQuestionIndex < 0,
 		previousQuestion =
-			currentQuestionIndex < 0 && previousAnswers.length > 0
-				? previousAnswers[previousAnswers.length - 1]
-				: mosaicQuestion
+			currentIsNew && previousAnswers.length > 0
+				? // it simply is the last answered question
+				  previousAnswers[previousAnswers.length - 1]
+				: // mosaics are exceptionnal, since they are similar questions grouped for the UI
+				mosaicQuestion
 				? [...previousAnswers].reverse().find((el, index) => {
 						return (
 							index > previousAnswers.length - currentQuestionIndex &&

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -221,8 +221,10 @@ export default function Conversation({
 				mosaicQuestion
 				? // We'll explore the previous answers starting from the end, to find the first question that is not in the current mosaic
 				  [...previousAnswers].reverse().find((el, index) => {
+						const currentQuestionReversedIndex =
+							previousAnswers.length - currentQuestionIndex
 						return (
-							index > previousAnswers.length - currentQuestionIndex &&
+							index > currentQuestionReversedIndex &&
 							// The previous question shouldn't be one of the current mosaic's questions
 							!questionsToSubmit.includes(el)
 						)


### PR DESCRIPTION
Permet normalement de résoudre un bug sur le bouton précédent du aux mosaïques 

On revient toujours sur la même mosaïque ici : on revient toujours sur la mosaïque numérique par exemple

![Kapture 2023-03-22 at 19 09 46](https://user-images.githubusercontent.com/55186402/227248525-019d8108-f06b-40e2-abaa-67e389555763.gif)

