### PR TITLE
🐛Fix bouton "précédent"

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -472,17 +472,21 @@ export default function Conversation({
 					</fieldset>
 				</div>
 				<div className="ui__ answer-group">
-					{previousAnswers.length > 0 && currentQuestionIndex !== 0 && (
-						<>
-							<button
-								onClick={goToPrevious}
-								type="button"
-								className="ui__ simple small push-left button"
-							>
-								← <Trans>Précédent</Trans>
-							</button>
-						</>
-					)}
+					{previousAnswers.length > 0 &&
+						// We check that the question is not the first question
+						currentQuestionIndex !== 0 &&
+						// We check that previousQuestion found is in the rules (as the model evolves, the question found can be out of the new rules)
+						rules[previousQuestion] && (
+							<>
+								<button
+									onClick={goToPrevious}
+									type="button"
+									className="ui__ simple small push-left button"
+								>
+									← <Trans>Précédent</Trans>
+								</button>
+							</>
+						)}
 					{currentQuestionIsAnswered ? (
 						<button
 							className="ui__ plain small button"


### PR DESCRIPTION
Je fix ici un problème avec le bouton précédent:

si on cherchait à revenir sur une question dont la règle n'est plus dans le modèle, ça cassait l'app

Exemple: 'xxx . présent' transformée en 'xxx . nombre'
Précédent vers 'xxx . présent' pourtant des les previousAnswers cassait l'app