### PR TITLE
Corrige l'affichage des labels de pays à deux mots, passe à une utilisation de grid

### DIFF
--- a/source/components/localisation/RegionGrid.tsx
+++ b/source/components/localisation/RegionGrid.tsx
@@ -15,12 +15,17 @@ export default ({ noButton }) => {
 			css={`
 				padding: 0;
 				margin-top: 1rem;
-				display: flex;
-				flex-wrap: wrap;
-				justify-content: space-evenly;
+				display: grid;
+				grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+				gap: 1rem;
 				li {
-					margin: 0.4rem 0.6rem;
+					margin: 0.4rem 0;
+					display: flex;
+					justify-content: center;
 					list-style-type: none;
+				}
+				@media (max-width: 400px) {
+					grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
 				}
 			`}
 		>
@@ -60,9 +65,12 @@ const listItemStyle = `
 	font-size: 0.75rem;
 	color: var(--darkColor);
 	text-align: left;
+	line-height: 1;
+	
 	img {
 		margin-right: 0.6rem;
 	}
+
 	@media (max-width: 400px) {
 		width: 6rem !important;
 		flex-direction: column;
@@ -70,6 +78,10 @@ const listItemStyle = `
 		text-align: center;
 		justify-content: center;
 		height: 4rem;
+
+		img {
+			margin-bottom: 0.5rem;
+		}
 	}
 `
 const ListItemComponent = ({ code, noButton, label }) =>

--- a/source/components/localisation/RegionGrid.tsx
+++ b/source/components/localisation/RegionGrid.tsx
@@ -13,6 +13,8 @@ export default ({ noButton }) => {
 	return (
 		<ul
 			css={`
+				max-width: 760px;
+				margin: 0 auto;
 				padding: 0;
 				margin-top: 1rem;
 				display: grid;


### PR DESCRIPTION
J'ai noté qu'il y avait un souci sur le style des pays à deux mots. J'en ai profité pour passer sur une utilisation de grid pour avec une grille bien carrée.
J'ai aussi ajouté une max-width sur le conteneur des cards de pays pour faciliter la lecture :


<img width="1438" alt="Capture d’écran 2023-04-06 à 10 25 24" src="https://user-images.githubusercontent.com/12382534/230319516-74283581-4d92-4114-86d6-5ecc2429613e.png">
