### PR TITLE
🎨 Style point info

### DIFF
--- a/source/components/conversation/Explicable.tsx
+++ b/source/components/conversation/Explicable.tsx
@@ -1,6 +1,5 @@
 import { explainVariable } from 'Actions/actions'
 import { useContext } from 'react'
-import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'
 import { DottedName } from 'Rules'
 import { TrackerContext } from '../../contexts/TrackerContext'
@@ -16,7 +15,6 @@ export function ExplicableRule({ dottedName }: { dottedName: DottedName }) {
 
 	return (
 		<button
-			className="ui__ link-button"
 			type="button"
 			onClick={(e) => {
 				tracker.push(['trackEvent', 'help', dottedName])
@@ -29,11 +27,12 @@ export function ExplicableRule({ dottedName }: { dottedName: DottedName }) {
 			}}
 			css={`
 				margin-left: 0.3rem !important;
-				vertical-align: middle;
 				font-size: 110% !important;
+				padding-left: 0.6rem;
+				padding: 0;
 			`}
 		>
-			{emoji('ℹ️')}
+			ℹ️
 		</button>
 	)
 }

--- a/source/components/conversation/Explicable.tsx
+++ b/source/components/conversation/Explicable.tsx
@@ -32,7 +32,17 @@ export function ExplicableRule({ dottedName }: { dottedName: DottedName }) {
 				padding: 0;
 			`}
 		>
-			ℹ️
+			<img
+				src="/images/info.svg"
+				width="10"
+				height="10"
+				css={`
+					width: 2rem;
+					height: auto;
+					vertical-align: middle;
+				`}
+				alt="Obtenir de l'aide pour cette saisie"
+			/>
 		</button>
 	)
 }

--- a/source/components/conversation/Question.tsx
+++ b/source/components/conversation/Question.tsx
@@ -4,7 +4,6 @@ import { Markdown } from 'Components/utils/markdown'
 import { ASTNode } from 'publicodes'
 import { Rule } from 'publicodes/dist/types/rule'
 import React, { Suspense, useCallback, useEffect, useState } from 'react'
-import emoji from 'react-easy-emoji'
 import { Trans, useTranslation } from 'react-i18next'
 import AnimatedLoader from '../../AnimatedLoader'
 import {
@@ -229,16 +228,16 @@ export const RadioLabel = (props: RadioLabelProps) => {
 			{props.description && (
 				<>
 					<button
-						className="ui__ link-button"
 						type="button"
 						onClick={() => setIsOpen(!isOpen)}
 						css={`
-							margin-left: 0.3rem !important;
 							vertical-align: middle;
 							font-size: 110% !important;
+							padding: 0;
+							padding-left: 0.6rem;
 						`}
 					>
-						{emoji('ℹ️')}
+						ℹ️
 					</button>
 					{isOpen && (
 						<animate.appear>
@@ -314,7 +313,7 @@ function RadioLabelContent({
 			/>
 			<span>
 				<span className="radioText">{label}</span>
-				{icônes && <span css="margin-left: .6rem">{emoji(icônes)}</span>}
+				{icônes && <span css="margin-left: .6rem">{icônes}</span>}
 			</span>
 		</label>
 	)

--- a/source/images/info.svg
+++ b/source/images/info.svg
@@ -4,7 +4,7 @@
    viewBox="0 0 72 72"
    version="1.1"
    sodipodi:docname="info.svg"
-   inkscape:version="1.1.1 (1:1.1+202109281954+c3084ef5ed)"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,26 +20,28 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="8.43825"
-     inkscape:cx="47.521702"
-     inkscape:cy="34.959855"
+     inkscape:zoom="3.6585706"
+     inkscape:cx="16.536513"
+     inkscape:cy="18.449828"
      inkscape:window-width="1920"
-     inkscape:window-height="1200"
+     inkscape:window-height="1175"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="line" />
+     inkscape:current-layer="line"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <g
      id="line">
     <g
        id="color"
-       transform="matrix(1.9664,0,0,1.9664,-53.714467,-7.805469)" />
+       transform="matrix(2.1825243,0,0,2.1825243,-64.977958,-8.1095984)" />
     <circle
-       style="fill:#fcea2b;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#5a5bbc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.43963;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path2372"
-       cy="32.658627"
-       cx="37.212349"
-       r="27.573122" />
+       cy="36.801853"
+       cx="35.942497"
+       r="30.603645" />
     <polyline
        fill="none"
        stroke="#000000"
@@ -48,23 +50,25 @@
        stroke-width="2.5"
        points="46.892 26.339 46.892 20.594 43.989 20.594"
        id="polyline17"
-       transform="matrix(1.9664,0,0,1.9664,-53.714467,-7.805469)" />
+       transform="matrix(2.1825243,0,0,2.1825243,-64.977958,-8.1095984)"
+       style="stroke:#ffffff;stroke-opacity:1" />
     <line
-       x1="43.920441"
-       x2="32.655327"
-       y1="43.98735"
-       y2="43.98735"
+       x1="43.387867"
+       x2="30.884621"
+       y1="49.375702"
+       y2="49.375702"
        fill="none"
        stroke="#000000"
        stroke-linecap="round"
        stroke-linejoin="round"
-       stroke-width="4.916"
-       id="line19" />
+       stroke-width="5.45631"
+       id="line19"
+       style="stroke:#ffffff;stroke-opacity:1" />
     <circle
-       cx="37.897552"
-       cy="22.874306"
-       r="3.7544475"
+       cx="36.703011"
+       cy="25.942146"
+       r="4.1670938"
        id="circle21"
-       style="stroke-width:1.9664" />
+       style="stroke-width:2.18252;fill:#ffffff;fill-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
Je me permets d'ouvrir une nouvelle PR au sujet du style du point info qui retardait la mise en ligne de #905 

L'objectif ici est d'améliorer le style de l'emoji du point info.


> [Clément] Je suis pas ultra convaincu par les emojis natifs pour ce bouton assez structurant mine de rien et visible partout (ou pas assez justement). Le point info de twemoji est peut etre pas optimal mais on pourrait peut etre dans ce cas en faire un custom ?

> [Maël] On a /source/images/info.svg, tu en penses quoi ? On peut le colorier en mauve