### PR TITLE
Proposition de fix pour nos stats de conversation

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -99,7 +99,7 @@ export default function Conversation({
 	const tracking = useSelector((state) => state.tracking)
 
 	useEffect(() => {
-		if (!tracking.firstQuestionEventFired && previousAnswers.length === 1) {
+		if (!tracking.firstQuestionEventFired && previousAnswers.length >= 1) {
 			tracker.push(['trackEvent', 'NGC', '1ère réponse au bilan'])
 			dispatch(setTrackingVariable('firstQuestionEventFired', true))
 		}

--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -100,6 +100,7 @@ export default function Conversation({
 
 	useEffect(() => {
 		if (!tracking.firstQuestionEventFired && previousAnswers.length >= 1) {
+			console.log('1ère réponse au bilan')
 			tracker.push(['trackEvent', 'NGC', '1ère réponse au bilan'])
 			dispatch(setTrackingVariable('firstQuestionEventFired', true))
 		}
@@ -110,11 +111,13 @@ export default function Conversation({
 	useEffect(() => {
 		// This will help you judge if the "A terminé la simulation" event has good numbers
 		if (!tracking.progress90EventFired && progress > 0.9) {
+			console.log('90% réponse au bilan')
 			tracker.push(['trackEvent', 'NGC', 'Progress > 90%'])
 			dispatch(setTrackingVariable('progress90EventFired', true))
 		}
 
 		if (!tracking.progress50EventFired && progress > 0.5) {
+			console.log('50% réponse au bilan')
 			tracker.push(['trackEvent', 'NGC', 'Progress > 50%'])
 			dispatch(setTrackingVariable('progress50EventFired', true))
 		}


### PR DESCRIPTION
Fixes  #949

- 1) tester ce fix
- 2) après analyse des résultats sur les stats de demain, enlever des objectifs les tests complétés qui sont faits avec un clic sur un des personas