### PR TITLE
fix(build): markdown loading in dev mode working

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
 		"prettier": "^2.7.1",
 		"prettier-plugin-organize-imports": "^3.1.1",
 		"prompt-sync": "^4.2.0",
-		"raw-loader": "^4.0.2",
 		"style-loader": "^3.3.1",
 		"toml-loader": "^1.0.0",
 		"typescript": "^4.7.4",

--- a/source/sites/publicodes/LandingExplanations.tsx
+++ b/source/sites/publicodes/LandingExplanations.tsx
@@ -6,10 +6,10 @@ import avantages from './avantages.yaml'
 import LandingContent from './LandingContent'
 import MarkdownPage from './pages/MarkdownPage'
 
-import contentEn from 'raw-loader!../../locales/pages/en-us/landing.md'
-import contentEs from 'raw-loader!../../locales/pages/es/landing.md'
-import contentFr from 'raw-loader!../../locales/pages/fr/landing.md'
-import contentIt from 'raw-loader!../../locales/pages/it/landing.md'
+import contentEn from '../../locales/pages/en-us/landing.md'
+import contentEs from '../../locales/pages/es/landing.md'
+import contentFr from '../../locales/pages/fr/landing.md'
+import contentIt from '../../locales/pages/it/landing.md'
 
 const fluidLayoutMinWidth = '1200px'
 

--- a/source/sites/publicodes/pages/About.tsx
+++ b/source/sites/publicodes/pages/About.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/about.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/about.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/about.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/about.md'
+import contentEn from '../../../locales/pages/en-us/about.md'
+// import contentEs from '../../../locales/pages/es/about.md'
+import contentFr from '../../../locales/pages/fr/about.md'
+// import contentIt from '../../../locales/pages/it/about.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/Accessibility.tsx
+++ b/source/sites/publicodes/pages/Accessibility.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/accessibility.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/accessibility.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/accessibility.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/accessibility.md'
+import contentEn from '../../../locales/pages/en-us/accessibility.md'
+// import contentEs from '../../../locales/pages/es/accessibility.md'
+import contentFr from '../../../locales/pages/fr/accessibility.md'
+// import contentIt from '../../../locales/pages/it/accessibility.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/CGU.tsx
+++ b/source/sites/publicodes/pages/CGU.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/CGU.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/CGU.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/CGU.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/CGU.md'
+import contentEn from '../../../locales/pages/en-us/CGU.md'
+// import contentEs from '../../../locales/pages/es/CGU.md'
+import contentFr from '../../../locales/pages/fr/CGU.md'
+// import contentIt from '../../../locales/pages/it/CGU.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/Diffuser.tsx
+++ b/source/sites/publicodes/pages/Diffuser.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/diffuser.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/diffuser.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/diffuser.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/diffuser.md'
+import contentEn from '../../../locales/pages/en-us/diffuser.md'
+// import contentEs from '../../../locales/pages/es/diffuser.md'
+import contentFr from '../../../locales/pages/fr/diffuser.md'
+// import contentIt from '../../../locales/pages/it/diffuser.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/DocumentationContexte.tsx
+++ b/source/sites/publicodes/pages/DocumentationContexte.tsx
@@ -6,10 +6,10 @@ import { Link } from 'react-router-dom'
 
 import { getLangInfos, Lang } from '../../../locales/translation'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/documentation.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/documentation.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/documentation.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/documentation.md'
+import contentEn from '../../../locales/pages/en-us/documentation.md'
+// import contentEs from '../../../locales/pages/es/documentation.md'
+import contentFr from '../../../locales/pages/fr/documentation.md'
+// import contentIt from '../../../locales/pages/it/documentation.md'
 
 export default () => {
 	const { t, i18n } = useTranslation()

--- a/source/sites/publicodes/pages/Méthode.tsx
+++ b/source/sites/publicodes/pages/Méthode.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/méthode.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/méthode.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/méthode.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/méthode.md'
+import contentEn from '../../../locales/pages/en-us/méthode.md'
+// import contentEs from '../../../locales/pages/es/méthode.md'
+import contentFr from '../../../locales/pages/fr/méthode.md'
+// import contentIt from '../../../locales/pages/it/méthode.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/PetrogazLanding.tsx
+++ b/source/sites/publicodes/pages/PetrogazLanding.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/petrogazLanding.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/petrogazLanding.md'
+import contentEn from '../../../locales/pages/en-us/petrogazLanding.md'
+import contentFr from '../../../locales/pages/fr/petrogazLanding.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/source/sites/publicodes/pages/Privacy.tsx
+++ b/source/sites/publicodes/pages/Privacy.tsx
@@ -2,10 +2,10 @@ import { useTranslation } from 'react-i18next'
 import { Lang } from '../../../locales/translation'
 import MarkdownPage from './MarkdownPage'
 
-import contentEn from 'raw-loader!../../../locales/pages/en-us/privacy.md'
-// import contentEs from 'raw-loader!../../../locales/pages/es/privacy.md'
-import contentFr from 'raw-loader!../../../locales/pages/fr/privacy.md'
-// import contentIt from 'raw-loader!../../../locales/pages/it/privacy.md'
+import contentEn from '../../../locales/pages/en-us/privacy.md'
+// import contentEs from '../../../locales/pages/es/privacy.md'
+import contentFr from '../../../locales/pages/fr/privacy.md'
+// import contentIt from '../../../locales/pages/it/privacy.md'
 
 export default () => {
 	const { t } = useTranslation()

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -116,7 +116,11 @@ module.exports.commonLoaders = (mode = 'production') => {
 			exclude: /node_modules|dist/,
 		},
 		{
-			test: /\.(jpe?g|png)$/,
+			test: /\.md/,
+			type: 'asset/source',
+		},
+		{
+			test: /\.(jpe?g|png|gif)$/i,
 			type: 'asset/resource',
 		},
 		{

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,18 +13,7 @@ const {
 module.exports = {
 	...common,
 	module: {
-		rules: [
-			...commonLoaders('development'),
-			styleLoader('style-loader'),
-			{
-				test: /\.(png|jpe?g|gif|md)$/i,
-				use: [
-					{
-						loader: 'file-loader',
-					},
-				],
-			},
-		],
+		rules: [...commonLoaders('development'), styleLoader('style-loader')],
 	},
 	devServer: {
 		historyApiFallback: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7203,14 +7203,6 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz"
-  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 react-color@^2.14.0:
   version "2.19.3"
   resolved "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz"


### PR DESCRIPTION
Markdown files weren't correctly loaded in dev mode. It was caused by [this changes](https://github.com/datagir/nosgestesclimat-site/commit/47b74a3abad340d86080edc21f5a312831fab3a0#diff-52cf7951fec7ee5c8db1888ab977bc94c938511c211beecca96a1ebb64a4dafaR19-R26).
 
This PR introduces changes to use the new webpack [Asset Modules](https://webpack.js.org/guides/asset-modules/) instead of the deprecated `raw-loader` in webpack >v5.