### PR TITLE
Suppression des références publicodes de la bulle d'aide de question

### DIFF
--- a/source/components/conversation/Aide.tsx
+++ b/source/components/conversation/Aide.tsx
@@ -39,16 +39,6 @@ export default function Aide() {
 			>
 				{rule.title && <h2>{rule.title}</h2>}
 				<Markdown>{text}</Markdown>
-				{refs && (
-					<>
-						<h3>
-							<Trans>En savoir plus</Trans>
-						</h3>
-						<Suspense fallback={<AnimatedLoader />}>
-							<ReferencesLazy refs={refs} />
-						</Suspense>
-					</>
-				)}
 				<button onClick={stopExplaining} className="ui__ button simple">
 					<Trans>Refermer</Trans>
 				</button>


### PR DESCRIPTION
Qui de toutes façon, du fait d'une mauvaise signature des props, ne marchait pas. 

Alors autant l'enlever, elle n'a semble-t-il manqué à personne. 

Note : le "En savoir plus" s'affichait toujours, mais sans afficher les références :sweat_smile: 

@lbranaa je crois que tu en avais parlé ?