### PR TITLE
Ajout tracker à la création des "salles"

### DIFF
--- a/source/sites/publicodes/conference/LoadingButton.tsx
+++ b/source/sites/publicodes/conference/LoadingButton.tsx
@@ -1,10 +1,13 @@
 import { motion } from 'framer-motion'
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { TrackerContext } from '../../../contexts/TrackerContext'
 import { surveysURL } from './useDatabase'
 
 export default ({ mode, URLPath, room }) => {
+	const tracker = useContext(TrackerContext)
+
 	const [clicked, setClicked] = useState(false)
 	const [text, setText] = useState(null)
 
@@ -24,6 +27,7 @@ export default ({ mode, URLPath, room }) => {
 					setClicked(true)
 
 					if (mode === 'conférence') {
+						tracker.push(['trackEvent', 'Mode Groupe', 'Création salle', mode])
 						return setTimeout(() => navigate(URLPath), 3000)
 					}
 					const request = await fetch(surveysURL, {
@@ -53,6 +57,8 @@ export default ({ mode, URLPath, room }) => {
 					}
 
 					setText(t('Sondage créé'))
+
+					tracker.push(['trackEvent', 'Mode Groupe', 'Création salle', mode])
 
 					return setTimeout(() => {
 						navigate(URLPath)


### PR DESCRIPTION
Pour ne pas noyer l'ajout dans #942, j'ouvre cette PR séparément.

Je propose ici de capter les clics sur le bouton de création des modes "groupes" pour évaluer l'utilisation de l'un ou l'autre des modes notamment