### PR TITLE
On enlève les personas des chiffres de conversion 

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -22,7 +22,10 @@ import {
 } from '../../actions/actions'
 import Meta from '../../components/utils/Meta'
 import { TrackerContext } from '../../contexts/TrackerContext'
-import { objectifsSelector } from '../../selectors/simulationSelectors'
+import {
+	isPersonaSelector,
+	objectifsSelector,
+} from '../../selectors/simulationSelectors'
 import { sortBy, useQuery } from '../../utils'
 import { questionCategoryName, splitName, title } from '../publicodesUtils'
 import SafeCategoryImage from '../SafeCategoryImage'
@@ -108,16 +111,17 @@ export default function Conversation({
 	}, [tracker, previousAnswers])
 
 	const progress = useSimulationProgress()
+	const isPersona = useSelector(isPersonaSelector)
 
 	useEffect(() => {
 		// This will help you judge if the "A terminé la simulation" event has good numbers
-		if (!tracking.progress90EventFired && progress > 0.9) {
+		if (!tracking.progress90EventFired && progress > 0.9 && !isPersona) {
 			console.log('90% réponse au bilan')
 			tracker.push(['trackEvent', 'NGC', 'Progress > 90%'])
 			dispatch(setTrackingVariable('progress90EventFired', true))
 		}
 
-		if (!tracking.progress50EventFired && progress > 0.5) {
+		if (!tracking.progress50EventFired && progress > 0.5 && !isPersona) {
 			console.log('50% réponse au bilan')
 			tracker.push(['trackEvent', 'NGC', 'Progress > 50%'])
 			dispatch(setTrackingVariable('progress50EventFired', true))
@@ -293,7 +297,7 @@ export default function Conversation({
 	const bilan = Math.round(engine.evaluate('bilan').nodeValue)
 
 	useEffect(() => {
-		if (!endEventFired && noQuestionsLeft) {
+		if (!endEventFired && noQuestionsLeft && !isPersona) {
 			tracker.push([
 				'trackEvent',
 				'NGC',

--- a/source/selectors/simulationSelectors.ts
+++ b/source/selectors/simulationSelectors.ts
@@ -48,5 +48,5 @@ export const answeredQuestionsSelector = (state: RootState) =>
 
 export const isPersonaSelector = createSelector(
 	[currentSimulationSelector],
-	(simulation) => simulation.persona != null
+	(simulation) => simulation?.persona != null
 )

--- a/source/selectors/simulationSelectors.ts
+++ b/source/selectors/simulationSelectors.ts
@@ -45,6 +45,7 @@ export const currentQuestionSelector = (state: RootState) =>
 
 export const answeredQuestionsSelector = (state: RootState) =>
 	state.simulation?.foldedSteps ?? []
+
 export const isPersonaSelector = createSelector(
 	[currentSimulationSelector],
 	(simulation) => simulation.persona != null

--- a/source/selectors/simulationSelectors.ts
+++ b/source/selectors/simulationSelectors.ts
@@ -1,6 +1,7 @@
-import { DottedName, Situation } from '../rules/index'
-import { createSelector } from 'reselect'
 import { RootState, SimulationConfig } from 'Reducers/rootReducer'
+import { createSelector } from 'reselect'
+import { DottedName, Situation } from '../rules/index'
+import { currentSimulationSelector } from './storageSelectors'
 
 export const configSelector = (state: RootState): Partial<SimulationConfig> =>
 	state.simulation?.config ?? {}
@@ -44,3 +45,7 @@ export const currentQuestionSelector = (state: RootState) =>
 
 export const answeredQuestionsSelector = (state: RootState) =>
 	state.simulation?.foldedSteps ?? []
+export const isPersonaSelector = createSelector(
+	[currentSimulationSelector],
+	(simulation) => simulation.persona != null
+)


### PR DESCRIPTION
- Nouveau selecteur pour savoir si un persona a été sélectionné
- On considère qu'une simulation faite via un persona n'est pas un succès

Cette PR répond à une faille potentielle (qu'on a trouvée avec @bjlaa au cours d'une discussion je crois) pour le funnel de mesure de la complétion du test. 

L'événement était déclenché avec le parcours ci-dessous :
- je fais mon test en partie, ou je ne le fais pas du tout
- je vais sur /actions (via la menu probablement)
- je clique sur un persona
- important : je reviens sur le test sur /simulateur/bilan, c'est là que
  les événements sont déclenchés

Les événements étaient codés de façon un peu brute, sans prendre en compte cette subtilité du parcours. 
