### PR TITLE
Ajoute le bout de code recommandé par Matomo pour une bonne prise en compte des iframe

### DIFF
--- a/source/contexts/TrackerContext/Tracker.ts
+++ b/source/contexts/TrackerContext/Tracker.ts
@@ -39,11 +39,15 @@ export default class Tracker {
 			// iFrame -- to avoid errors in the number of visitors in our stats.
 			if (iOSSafari && inIframe()) return
 
-			// Could be due to an adblocker not allowing the script to set this global attribute
-			if (!window.plausible) return
+			if (inIframe()) {
+				window._paq.push(['setCookieSameSite', 'None'])
+			}
 
 			// Create new array to avoid mutating original
 			window._paq.push([...args])
+
+			// Could be due to an adblocker not allowing the script to set this global attribute
+			if (!window.plausible) return
 
 			// pour plausible, je n'envoie que les events
 			// les pages vues sont gérées de base


### PR DESCRIPTION
Suite à une discussion avec Florian, il m'a partagé l'info que ICO2 avait le même problème que nous concernant les chiffres visiteurs uniques > visites totales et que cela provenait certainement des intégrations iframe. Je suis alors tombé sur cet article :
https://fr.matomo.org/faq/how-to/how-do-i-track-a-website-within-an-iframe/
On peut essayer et voir ce que ça donne sur les prochains jours.

