### PR TITLE
Migration Sentry Beta

### DIFF
--- a/source/contexts/MatomoContext.tsx
+++ b/source/contexts/MatomoContext.tsx
@@ -10,6 +10,8 @@ const groupExclusionRegexp = /\/(sondage|conférence)\//
 const shouldUseDevTracker =
 	NODE_ENV === 'development' || CONTEXT === 'deploy-preview'
 
+console.log(CONTEXT)
+
 const ua = window.navigator.userAgent
 // https://chromium.googlesource.com/chromium/src.git/+/master/docs/ios/user_agent.md
 const iOSSafari =

--- a/source/contexts/MatomoContext.tsx
+++ b/source/contexts/MatomoContext.tsx
@@ -10,8 +10,6 @@ const groupExclusionRegexp = /\/(sondage|conférence)\//
 const shouldUseDevTracker =
 	NODE_ENV === 'development' || CONTEXT === 'deploy-preview'
 
-console.log(CONTEXT)
-
 const ua = window.navigator.userAgent
 // https://chromium.googlesource.com/chromium/src.git/+/master/docs/ios/user_agent.md
 const iOSSafari =

--- a/source/sites/publicodes/entry.js
+++ b/source/sites/publicodes/entry.js
@@ -10,6 +10,7 @@ Sentry.init({
 	integrations: [new Sentry.BrowserTracing()],
 	// NOTE(@EmileRoley): Quite an arbitrary value
 	tracesSampleRate: 0.25,
+	enabled: process.env.NODE_ENV !== 'development',
 })
 
 Object.keys(Lang).forEach((lang) => {

--- a/source/sites/publicodes/entry.js
+++ b/source/sites/publicodes/entry.js
@@ -6,7 +6,6 @@ import { getLangInfos, Lang } from '../../locales/translation'
 import App from './App'
 
 Sentry.init({
-	dsn: 'https://d134af84d6db41eea0331919c58865b9@o4505041038606336.ingest.sentry.io/4505041042014208',
 	integrations: [new Sentry.BrowserTracing()],
 	// NOTE(@EmileRoley): Quite an arbitrary value
 	tracesSampleRate: 0.25,

--- a/source/sites/publicodes/entry.js
+++ b/source/sites/publicodes/entry.js
@@ -5,6 +5,8 @@ import i18next from '../../locales/i18n'
 import { getLangInfos, Lang } from '../../locales/translation'
 import App from './App'
 
+console.log(CONTEXT)
+
 Sentry.init({
 	dsn: SENTRY_DSN,
 	integrations: [new Sentry.BrowserTracing()],

--- a/source/sites/publicodes/entry.js
+++ b/source/sites/publicodes/entry.js
@@ -5,14 +5,13 @@ import i18next from '../../locales/i18n'
 import { getLangInfos, Lang } from '../../locales/translation'
 import App from './App'
 
-console.log(CONTEXT)
-
 Sentry.init({
 	dsn: SENTRY_DSN,
 	integrations: [new Sentry.BrowserTracing()],
 	// NOTE(@EmileRoley): Quite an arbitrary value
 	tracesSampleRate: 0.25,
 	enabled: process.env.NODE_ENV !== 'development',
+	environment: CONTEXT,
 })
 
 Object.keys(Lang).forEach((lang) => {

--- a/source/sites/publicodes/entry.js
+++ b/source/sites/publicodes/entry.js
@@ -6,6 +6,7 @@ import { getLangInfos, Lang } from '../../locales/translation'
 import App from './App'
 
 Sentry.init({
+	dsn: SENTRY_DSN,
 	integrations: [new Sentry.BrowserTracing()],
 	// NOTE(@EmileRoley): Quite an arbitrary value
 	tracesSampleRate: 0.25,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -42,6 +42,7 @@ module.exports = {
 			NODE_ENV: JSON.stringify('production'),
 			SERVER_URL: JSON.stringify(process.env.SERVER_URL),
 			CONTEXT: JSON.stringify(process.env.CONTEXT),
+			SENTRY_DSN: JSON.stringify(process.env.SENTRY_DSN),
 		}),
 	],
 }


### PR DESCRIPTION
Je teste ici en ajoutant le dsn dans les variables d'environnement

A noter :

- La variable d'environnement SENTRY_DSN n'est pas détectée automatiquement (nécessaire de définir l'option dans `init`)
- Après qques tests, il semble que nous ne recevons pas les évènements Sentry depuis localhost **même sans désactivation à la main via l'option 'enabled'**
- Il ne semble pas possible de désactiver l'email depuis les options de la fenêtre de dialogue Sentry **[doc ici]**.(https://docs.sentry.io/platforms/javascript/guides/react/enriching-events/user-feedback/#customizing-the-widget)