### PR TITLE
Ajoute le Matomo cloud

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,11 @@
 				var u = '//stats.data.gouv.fr/'
 				_paq.push(['setTrackerUrl', u + 'matomo.php'])
 				_paq.push(['setSiteId', '153'])
+				_paq.push([
+					'addTracker',
+					'https://nosgestesclimat.matomo.cloud/matomo.php',
+					'2',
+				])
 				var d = document,
 					g = d.createElement('script'),
 					s = d.getElementsByTagName('script')[0]


### PR DESCRIPTION
J'ai créé un nouveau compte Matomo sur le cloud. Ce dernier nous permettrait de nous affranchir des limitations de l'instance Matomo que nous avons utilisée jusqu'ici, notamment en terme de limites d'URL suivies, de complexité des requêtes (possibilité de requêter les visiteurs unique sur une durée plus grande qu'une journée).

Infos clés : 
* données stockées en Europe (Francfort, Allemagne)
* estimation de prix de l'abonnement : 69 euros par mois
* aucun changement sur la RGPD - nous avons désactivé les plugins qui nécessiteraient l'ajout d'une bannière à cookies
* avantages :
    * s'affranchir des limitations rencontrées sur la première instance Matomo
    * permettre d'utiliser les plugins Live (vision en temps réel de l'activité sur le site) et funnel
    * accessoire mais sympa : possibilité de changer le thème pour un plus sympathique.