### PR TITLE
Affichage permanent des actions sur /actions

### DIFF
--- a/source/components/ScoreExplanation.tsx
+++ b/source/components/ScoreExplanation.tsx
@@ -1,12 +1,16 @@
 import { motion } from 'framer-motion'
 import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { skipTutorial } from '../actions/actions'
 import TriangleShape from '../sites/publicodes/chart/TriangleShape'
 
 export default ({ openExplanation, setOpenExplanation, situationLength }) => {
 	const dispatch = useDispatch()
+	const location = useLocation()
+
+	if (!location.pathname.includes('simulateur/')) return null
+
 	const close = () => {
 		dispatch(skipTutorial('scoreExplanation'))
 		setOpenExplanation(false)

--- a/source/locales/ui/ui-en-us.yaml
+++ b/source/locales/ui/ui-en-us.yaml
@@ -470,10 +470,10 @@ entries:
   publicodes.Profil.recap.lock: Vous avez terminé le test à {{percentFinished}} % ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}} actions.
   publicodes.Profil.simulations: Every simulation you make is saved in your web browser. Only you have access to it.
   publicodes.Profil.simulations.lock: Chaque simulation que vous faite est sauvegardée dans votre navigateur Web. Vous êtes le seul à y avoir accès.
-  publicodes.SimulationMissing.personnas: 💡 You can also see the action course as if you were one of these sample profiles.
-  publicodes.SimulationMissing.personnas.lock: 💡 Vous pouvez aussi voir le parcours action comme si vous étiez l'un de ces profils types.
-  publicodes.SimulationMissing.simulationManquante: You haven't taken the test yet. To unlock this course, you need to tell us a little more about your lifestyle.
-  publicodes.SimulationMissing.simulationManquante.lock: Vous n'avez pas encore fait le test. Pour débloquer ce parcours, vous devez nous en dire un peu plus sur votre mode de vie.
+  publicodes.SimulationMissing.personnas: 💡 You can also continue with a <2>typical profile</2>.
+  publicodes.SimulationMissing.personnas.lock: 💡 Vous pouvez aussi continuer avec un <2>profil type</2>.
+  publicodes.SimulationMissing.simulationManquante: To unlock this course, you must first complete the test.
+  publicodes.SimulationMissing.simulationManquante.lock: Pour débloquer ce parcours, vous devez d'abord terminer le test.
   publicodes.TranslationContribution.commentaireAugmenté: |-
 
     &gt; This ticket was created automatically by our robot from our [translation contribution page](https://nosgestesclimat.fr/contribuer-traduction).

--- a/source/locales/ui/ui-fr.yaml
+++ b/source/locales/ui/ui-fr.yaml
@@ -380,8 +380,8 @@ entries:
   publicodes.Profil.locationDonnées: <0>Où sont mes données ? </0>Vos données sont stockées dans votre navigateur, vous avez donc le contrôle total sur elles. <2></2>
   publicodes.Profil.recap: Vous avez terminé le test à {{percentFinished}} % ({{answeredQuestionsLength}} questions) et choisi {{actionChoicesLength}} actions.
   publicodes.Profil.simulations: Chaque simulation que vous faite est sauvegardée dans votre navigateur Web. Vous êtes le seul à y avoir accès.
-  publicodes.SimulationMissing.personnas: 💡 Vous pouvez aussi voir le parcours action comme si vous étiez l'un de ces profils types.
-  publicodes.SimulationMissing.simulationManquante: Vous n'avez pas encore fait le test. Pour débloquer ce parcours, vous devez nous en dire un peu plus sur votre mode de vie.
+  publicodes.SimulationMissing.personnas: 💡 Vous pouvez aussi continuer avec un <2>profil type</2>.
+  publicodes.SimulationMissing.simulationManquante: Pour débloquer ce parcours, vous devez d'abord terminer le test.
   publicodes.TranslationContribution.commentaireAugmenté: |-
 
     > Ce ticket a été créé automatiquement par notre robot depuis notre [page de contribution pour la traduction](https://nosgestesclimat.fr/contribuer-traduction).

--- a/source/sites/publicodes/ActionsList.tsx
+++ b/source/sites/publicodes/ActionsList.tsx
@@ -62,14 +62,7 @@ export default ({ display }) => {
 	// but is it too restrictive ?
 	const simulationWellStarted = answeredQuestions.length > 50
 
-	if (!simulationWellStarted) {
-		return <SimulationMissing />
-	}
-
-	if (tutorials.actions !== 'skip') {
-		const [value, unit] = humanWeight({ t, i18n }, bilan.nodeValue)
-		return <ActionTutorial {...{ value, unit }} />
-	}
+	const [value, unit] = humanWeight({ t, i18n }, bilan.nodeValue)
 
 	return (
 		<div
@@ -79,6 +72,10 @@ export default ({ display }) => {
 				margin: 1rem auto;
 			`}
 		>
+			{!simulationWellStarted && <SimulationMissing />}
+			{simulationWellStarted && tutorials.actions !== 'skip' && (
+				<ActionTutorial {...{ value, unit }} />
+			)}
 			<MetricFilters selected={metric} />
 			<CategoryFilters
 				categories={categories}

--- a/source/sites/publicodes/Personas.tsx
+++ b/source/sites/publicodes/Personas.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { setDifferentSituation } from '../../actions/actions'
 import IllustratedMessage from '../../components/ui/IllustratedMessage'
 import useBranchData from '../../components/useBranchData'
@@ -148,6 +148,10 @@ export const PersonaGrid = ({
 	const branchData = useBranchData()
 	const lang = i18n.language === 'en' ? 'en-us' : i18n.language
 
+	const navigate = useNavigate()
+	const [params] = useSearchParams()
+	const redirect = params.get('redirect')
+
 	useEffect(() => {
 		if (!branchData.loaded) return
 		const fileName = `/personas-${lang}.json`
@@ -192,6 +196,7 @@ export const PersonaGrid = ({
 				foldedSteps: defaultMissingVariables,
 			})
 		)
+		if (redirect) navigate(redirect)
 	}
 	const hasSituation = Object.keys(situation).length
 	if (warning)

--- a/source/sites/publicodes/SimulationMissing.tsx
+++ b/source/sites/publicodes/SimulationMissing.tsx
@@ -1,7 +1,6 @@
 import { Trans } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import IllustratedMessage from '../../components/ui/IllustratedMessage'
-import { PersonaGrid } from './Personas'
 
 export default ({}) => {
 	return (
@@ -9,36 +8,28 @@ export default ({}) => {
 			className="ui__ card light colored content"
 			css="margin: 1.6em 0.5rem 1.6rem 0.5rem"
 		>
-			<h1>
-				<Trans>Simulation manquante</Trans>
-			</h1>
 			<IllustratedMessage
 				inline
-				emoji="⏳"
+				emoji="🔒"
 				message={
 					<p>
 						<Trans i18nKey={'publicodes.SimulationMissing.simulationManquante'}>
-							Vous n'avez pas encore fait le test. Pour débloquer ce parcours,
-							vous devez nous en dire un peu plus sur votre mode de vie.
+							Pour débloquer ce parcours, vous devez d'abord terminer le test.
 						</Trans>
 					</p>
 				}
 			/>
-			<div css="margin: 2rem auto 4rem; text-align: center">
+			<div css="margin: 2rem auto 1rem; text-align: center">
 				<Link to="/simulateur/bilan" className="ui__ plain button">
 					<Trans>Faire le test</Trans>
 				</Link>
 			</div>
-			<p css="text-align: center; max-width: 26rem; margin: 0 auto;">
+			<p css="text-align: center; max-width: 100%; margin: 0 auto;">
 				<Trans i18nKey={'publicodes.SimulationMissing.personnas'}>
-					💡 Vous pouvez aussi voir le parcours action comme si vous étiez l'un
-					de ces profils types.
+					💡 Vous pouvez aussi continuer avec un{' '}
+					<Link to="/personas">profil type</Link>.
 				</Trans>
 			</p>
-			<PersonaGrid
-				additionnalOnClick={() => null}
-				warningIfSituationExists={true}
-			/>
 		</div>
 	)
 }

--- a/source/sites/publicodes/SimulationMissing.tsx
+++ b/source/sites/publicodes/SimulationMissing.tsx
@@ -30,7 +30,7 @@ export default ({}) => {
 				<small>
 					<Trans i18nKey={'publicodes.SimulationMissing.personnas'}>
 						Vous pouvez aussi continuer avec un{' '}
-						<Link to="/personas">profil type</Link>.
+						<Link to={'/personas?redirect=/actions'}>profil type</Link>.
 					</Trans>
 				</small>
 			</p>

--- a/source/sites/publicodes/SimulationMissing.tsx
+++ b/source/sites/publicodes/SimulationMissing.tsx
@@ -1,34 +1,38 @@
 import { Trans } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import IllustratedMessage from '../../components/ui/IllustratedMessage'
 
 export default ({}) => {
 	return (
 		<div
 			className="ui__ card light colored content"
-			css="margin: 1.6em 0.5rem 1.6rem 0.5rem"
+			css={`
+				margin: 1.6em 0.5rem 1.6rem 0.5rem;
+				text-align: center;
+				padding: 1rem !important;
+			`}
 		>
-			<IllustratedMessage
-				inline
-				emoji="🔒"
-				message={
-					<p>
-						<Trans i18nKey={'publicodes.SimulationMissing.simulationManquante'}>
-							Pour débloquer ce parcours, vous devez d'abord terminer le test.
-						</Trans>
-					</p>
-				}
-			/>
-			<div css="margin: 2rem auto 1rem; text-align: center">
+			<p
+				css={`
+					text-align: center;
+				`}
+			>
+				🔒{' '}
+				<Trans i18nKey={'publicodes.SimulationMissing.simulationManquante'}>
+					Pour débloquer ce parcours, vous devez d'abord terminer le test.
+				</Trans>
+			</p>
+			<div css="margin: 1rem auto; text-align: center">
 				<Link to="/simulateur/bilan" className="ui__ plain button">
 					<Trans>Faire le test</Trans>
 				</Link>
 			</div>
-			<p css="text-align: center; max-width: 100%; margin: 0 auto;">
-				<Trans i18nKey={'publicodes.SimulationMissing.personnas'}>
-					💡 Vous pouvez aussi continuer avec un{' '}
-					<Link to="/personas">profil type</Link>.
-				</Trans>
+			<p css="text-align: center; margin: 0 ">
+				<small>
+					<Trans i18nKey={'publicodes.SimulationMissing.personnas'}>
+						Vous pouvez aussi continuer avec un{' '}
+						<Link to="/personas">profil type</Link>.
+					</Trans>
+				</small>
 			</p>
 		</div>
 	)


### PR DESCRIPTION
L'objectif : quand on arrive sur /actions, la liste des actions est présente sur la page. Pour le SEO surtout. 

- Popup d'explication du score non pertinente sur /actions
- L'avertissement "débloquage parcours action" ni le tuto ne doivent bloquer l'affichage de la liste des actions, pour quelles soient lisibles directement sur /actions par un moteur de recherche
- mise en retrait des personas, une fonctionnalité qui n'est pas grand publique, dans un petit lien
- réduction de la taille des textes de l'avertissement "débloquage"
- changment d'emoji pour un cadenas plutôt qu'un sablier
- simplification visuelle de l'avertissement pour laisser de la place aux actions notamment


![Recording 2023-05-31 at 19 18 47](https://github.com/datagir/nosgestesclimat-site/assets/1177762/85201a9b-465d-450a-8d6b-40fbd5042536)


