### PR TITLE
toString dans NorthStar casse en local et démo

### DIFF
--- a/source/components/Feedback/NorthstarBanner.tsx
+++ b/source/components/Feedback/NorthstarBanner.tsx
@@ -27,11 +27,11 @@ export default ({
 
 	const displayActionRating =
 		type === 'SET_RATING_ACTION' &&
-		hasRatedAction.toString().includes('display') &&
+		hasRatedAction?.toString().includes('display') &&
 		actionChoicesLength > 2
 	const displayLearnedRating =
 		type === 'SET_RATING_LEARNED' &&
-		hasRatedLearning.toString().includes('display')
+		hasRatedLearning?.toString().includes('display')
 
 	const closeFeedback = () => {
 		setTimeout(() => {


### PR DESCRIPTION
Petit fix, ça cassait en local et en démo

<img width="1436" alt="image" src="https://github.com/datagir/nosgestesclimat-site/assets/55186402/65b60003-5fb1-487d-8efc-188a269c0c54">
