### PR TITLE
Mauvaise URL d'accès à l'edge function netlify de geolocalisation

### DIFF
--- a/netlify/edge-functions/geolocation.ts
+++ b/netlify/edge-functions/geolocation.ts
@@ -1,46 +1,14 @@
-import { Context } from 'https://edge.netlify.com'
+/* eslint-disable @typescript-eslint/require-await */
+import type { Config, Context } from 'https://edge.netlify.com/'
 
+// deno-lint-ignore require-await
 export default async (request: Request, context: Context) => {
-	// Here's what's available on context.geo
-	// context: {
-	//   geo: {
-	//     city?: string;
-	//     country?: {
-	//       code?: string;
-	//       name?: string;
-	//     },
-	//     subdivision?: {
-	//       code?: string;
-	//       name?: string;
-	//     },
-	//   }
-	// }
-
 	return context.json({
 		geo: context.geo,
 		header: request.headers.get('x-nf-geo'),
 	})
+}
 
-	// util for tests
-
-	// return context.json({
-	// 	geo: { country: { code: 'NL', name: 'Netherlands' } },
-	// 	header: '{"country":{"code":"NL","name":"Netherlands"}',
-	// })
-	// return context.json({
-	// 	geo: { country: { code: 'US', name: 'United States' } },
-	// 	header: '{"country":{"code":"US","name":"United States"}}',
-	// })
-	// return context.json({
-	// 	geo: { country: { code: 'MQ', name: 'Martinique' } },
-	// 	header: '{"country":{"code":"MQ","name":"Martinique"}',
-	// })
-	// return context.json({
-	// 	geo: { country: { code: 'GP', name: 'Guadeloupe' } },
-	// 	header: '{"country":{"code":"GP","name":"Guadeloupe"}',
-	// })
-	// return context.json({
-	// 	geo: { country: { code: 'BE', name: 'Belgium' } },
-	// 	header: '{"country":{"code":"BE","name":"Belgium"}',
-	// })
+export const config: Config = {
+	path: '/geolocation',
 }

--- a/source/components/localisation/useLocalisation.ts
+++ b/source/components/localisation/useLocalisation.ts
@@ -1,4 +1,3 @@
-import { NETLIFY_FUNCTIONS_URL } from '@/constants/urls'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { setLocalisation } from '../../actions/actions'
@@ -20,7 +19,7 @@ export default () => {
 		}
 
 		const asyncFecthAPI = async () => {
-			await fetch(`${NETLIFY_FUNCTIONS_URL}${API}`)
+			await fetch(API)
 				.then((res) => {
 					const json = res.json()
 					return json


### PR DESCRIPTION
Corrige le problème ayant apparu récemment : la requête de géolocalisation échouait, ce qui faisait que la bannière d'erreur était systématiquement affichée.